### PR TITLE
Set up dummy homepage, /intake, /visit routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,14 +2,6 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import React, { useState, useReducer } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
-import Login from "./components/auth/Login";
-import Signup from "./components/auth/Signup";
-import PrivateRoute from "./components/auth/PrivateRoute";
-import CreatePage from "./components/pages/CreatePage";
-import Default from "./components/pages/Default";
-import DisplayPage from "./components/pages/DisplayPage";
-import NotFound from "./components/pages/NotFound";
-import UpdatePage from "./components/pages/UpdatePage";
 import * as Routes from "./constants/Routes";
 import AUTHENTICATED_USER_KEY from "./constants/AuthConstants";
 import AuthContext from "./contexts/AuthContext";
@@ -19,19 +11,24 @@ import SampleContext, {
 } from "./contexts/SampleContext";
 import sampleContextReducer from "./reducers/SampleContextReducer";
 import SampleContextDispatcherContext from "./contexts/SampleContextDispatcherContext";
-import EditTeamInfoPage from "./components/pages/EditTeamPage";
-import HooksDemo from "./components/pages/HooksDemo";
 
 import { AuthenticatedUser } from "./types/AuthTypes";
+import Login from "./components/auth/Login";
+import Signup from "./components/auth/Signup";
+import Intake from "./components/pages/IntakePage";
+import Visit from "./components/pages/VisitPage";
+import Home from "./components/pages/HomePage";
+import NotFound from "./components/pages/NotFound";
+
+// import PrivateRoute from "./components/auth/PrivateRoute";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
     AUTHENTICATED_USER_KEY,
   );
 
-  const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser>(
-    currentUser,
-  );
+  const [authenticatedUser, setAuthenticatedUser] =
+    useState<AuthenticatedUser>(currentUser);
 
   // Some sort of global state. Context API replaces redux.
   // Split related states into different contexts as necessary.
@@ -53,32 +50,11 @@ const App = (): React.ReactElement => {
             <Switch>
               <Route exact path={Routes.LOGIN_PAGE} component={Login} />
               <Route exact path={Routes.SIGNUP_PAGE} component={Signup} />
-              <PrivateRoute exact path={Routes.HOME_PAGE} component={Default} />
-              <PrivateRoute
-                exact
-                path={Routes.CREATE_ENTITY_PAGE}
-                component={CreatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.UPDATE_ENTITY_PAGE}
-                component={UpdatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.DISPLAY_ENTITY_PAGE}
-                component={DisplayPage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.EDIT_TEAM_PAGE}
-                component={EditTeamInfoPage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.HOOKS_PAGE}
-                component={HooksDemo}
-              />
+              {/* TODO: Change these to private routes */}
+              <Route exact path={Routes.HOME_PAGE} component={Home} />
+              <Route exact path={Routes.INTAKE_PAGE} component={Intake} />
+              <Route exact path={Routes.VISIT_PAGE} component={Visit} />
+
               <Route exact path="*" component={NotFound} />
             </Switch>
           </Router>

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Home = (): React.ReactElement => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>Homepage 🏠</h1>
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Intake = (): React.ReactElement => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>Intake 💨</h1>
+    </div>
+  );
+};
+
+export default Intake;

--- a/frontend/src/components/pages/VisitPage.tsx
+++ b/frontend/src/components/pages/VisitPage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Visit = (): React.ReactElement => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>Visit 📝</h1>
+    </div>
+  );
+};
+
+export default Visit;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -1,9 +1,10 @@
 export const HOME_PAGE = "/";
-
+export const INTAKE_PAGE = "/intake";
+export const VISIT_PAGE = "/visit";
 export const LOGIN_PAGE = "/login";
-
 export const SIGNUP_PAGE = "/signup";
 
+// TODO: Delete these
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const DISPLAY_ENTITY_PAGE = "/entity";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Set up dummy homepage, /intake, /visit routes](https://www.notion.so/uwblueprintexecs/Set-up-dummy-homepage-intake-visit-routes-92313fb02a58421d8c5297f68fc2acca)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add dummy homepage, intake and visit routes


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to `/`, `/intake`, `/visit`
2. Verify that the page changes

![routes](https://user-images.githubusercontent.com/32009013/171769009-5af15f24-aa2f-4efa-8993-22875154cb6a.gif)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
*  NOTE: These routes currently aren't protected (i.e. you don't need to be logged in to view it)! This will change later when we implement login/signup properly


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
