### PR TITLE
Add date to migration file name

### DIFF
--- a/backend/python/migrations/alembic.ini
+++ b/backend/python/migrations/alembic.ini
@@ -3,7 +3,7 @@
 [alembic]
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
-file_template = %%(year)d_%%(month).2d_%%(day).2d-%%(rev)s_%%(slug)s
+file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(rev)s_%%(slug)s
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false

--- a/backend/python/migrations/alembic.ini
+++ b/backend/python/migrations/alembic.ini
@@ -3,7 +3,7 @@
 [alembic]
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
-
+file_template = %%(year)d_%%(month).2d_%%(day).2d-%%(slug)s
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false

--- a/backend/python/migrations/alembic.ini
+++ b/backend/python/migrations/alembic.ini
@@ -3,7 +3,7 @@
 [alembic]
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
-file_template = %%(year)d_%%(month).2d_%%(day).2d-%%(slug)s
+file_template = %%(year)d_%%(month).2d_%%(day).2d-%%(rev)s_%%(slug)s
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false


### PR DESCRIPTION
Updated alembic.inic file to generate migration version file with a sequential naming.

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Update Alembic version naming convention](https://www.notion.so/uwblueprintexecs/Update-Alembic-version-naming-convention-8ca2f3719f284bc49443dbb16aa2971e)


## Implementation description
* Changed the file_template variable in the file alembic.inic such that it creates migration file versions with this naming format - YYYYMMDD-description


## Steps to test
1. Make changes to the schema and run migrations OR downgrade to base migration, then upgrade and finally generate a migration file
2. Verify that the migration file generated has naming of this format -> YYYYMMDD-description


## What should reviewers focus on?
* Does the migration file follow the specified format for it's naming?


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
