### PR TITLE
Enable heroku deployments

### DIFF
--- a/.github/workflows/heroku-deploy-dev-py.yml
+++ b/.github/workflows/heroku-deploy-dev-py.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   deploy:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/heroku-deploy-dev-py.yml
+++ b/.github/workflows/heroku-deploy-dev-py.yml
@@ -1,6 +1,9 @@
 name: Deploy backend to Heroku dev environment
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/heroku-deploy-dev-py.yml
+++ b/.github/workflows/heroku-deploy-dev-py.yml
@@ -1,9 +1,6 @@
 name: Deploy backend to Heroku dev environment
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Configure GitHub actions Heroku deploy on merge to main](https://www.notion.so/uwblueprintexecs/Configure-GitHub-actions-Heroku-deploy-on-merge-to-main-c318c1a04b5c4b589762631a9f308c5b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added all secrets defined in github workflow file to the repository
* re-enable heroku deployments


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Check that a heroku job was triggered for the `Test deployment` commit  ***NOTE: the job is only setup for running on `main` so it should fail on all PR branches
![image](https://user-images.githubusercontent.com/32009013/175460157-2abe6bee-5884-4749-8ba9-45b036d58408.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I need to remove this flag so I can troubleshoot deploying on main (i.e. there may be more PRs related to enabling heroku deployments later)


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
