### PR TITLE
Implement Get All Access Types Method

### DIFF
--- a/backend/python/app/services/implementations/access_type_service.py
+++ b/backend/python/app/services/implementations/access_type_service.py
@@ -25,6 +25,16 @@ class AccessTypeService(IAccessTypeService):
             self.logger.error(str(error))
             raise error
 
+    def get_access_types(self):
+        try:
+            return [
+                AccessTypeDTO(result.id, result.access_type)
+                for result in AccessType.query.all()
+            ]
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+
     def _add_new_access_type(self, access_type):
         try:
             new_access_type_entry = AccessType(access_type=access_type.upper())

--- a/backend/python/app/services/interfaces/access_type_service.py
+++ b/backend/python/app/services/interfaces/access_type_service.py
@@ -18,3 +18,13 @@ class IAccessTypeService(ABC):
         :raises Exception: if access type is invalid
         """
         pass
+
+    @abstractmethod
+    def get_access_types(self):
+        """
+        Fetches all access types in the db.
+        :return: List of access types
+        :rtype: list of AccessTypeDTO
+        :raises Exception: if querying the database fails
+        """
+        pass

--- a/backend/python/tests/unit/test_access_type_service.py
+++ b/backend/python/tests/unit/test_access_type_service.py
@@ -60,7 +60,7 @@ def test_get_access_type_null_arg_raises_exception(access_type_service):
 def test_get_access_types_success(access_type_service):
     res = access_type_service.get_access_types()
     assert type(res) == list
-    assert len(res) == 4
+    assert len(res) == len(DEFAULT_ACCESS_TYPES)
     assert all(type(item) == AccessTypeDTO for item in res)
     access_types_db = [entry["access_type"] for entry in DEFAULT_ACCESS_TYPES]
     access_type_res = [item.access_type for item in res]

--- a/backend/python/tests/unit/test_access_type_service.py
+++ b/backend/python/tests/unit/test_access_type_service.py
@@ -55,3 +55,13 @@ def test_get_access_type_invalid_arg_raises_exception(access_type_service):
 def test_get_access_type_null_arg_raises_exception(access_type_service):
     with pytest.raises(Exception):
         access_type_service.get_access_type(None)
+
+
+def test_get_access_types_success(access_type_service):
+    res = access_type_service.get_access_types()
+    assert type(res) == list
+    assert len(res) == 4
+    assert all(type(item) == AccessTypeDTO for item in res)
+    access_types_db = [entry["access_type"] for entry in DEFAULT_ACCESS_TYPES]
+    access_type_res = [item.access_type for item in res]
+    assert set(access_types_db) == set(access_type_res)


### PR DESCRIPTION
## Notion ticket link
[Get all access types](https://www.notion.so/uwblueprintexecs/Get-all-access-types-f59ba069dcc04109b18e84908133145b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `get_access_types` method to access type service files. Returns a list of `AccessTypeDTO` objects obtained by running `AccessType.query.all()`
* Log errors as strings

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. run `docker exec -it cas_py_backend /bin/bash -c "pip install -e . && pytest"`. Verify tests pass


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Verify that logging error as string is sufficient
* Test coverage


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
