### PR TITLE
Use common previous/next buttons for Intake navigation

### DIFF
--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -18,33 +18,29 @@ const Intake = (): React.ReactElement => {
 
   const prevStep = () => setStep(step - 1);
 
-  switch (step) {
-    case 1:
-      return (
-        <Box style={{ textAlign: "center", padding: "20px 0px 20px 0px" }}>
+  const renderFormPage = (currentStep: number) => {
+    switch (currentStep) {
+      case 1:
+        return (
           <ReferralForm
             referralDetails={referralDetails}
             setReferralDetails={setReferralDetails}
           />
-          <Button onClick={nextStep}>Next Button</Button>
-        </Box>
-      );
-    case 2:
-      return (
-        <Box style={{ textAlign: "center", padding: "20px 0px 20px 0px" }}>
-          <Heading textStyle="header-large">Intake 💨 2</Heading>
-          <Button onClick={prevStep}>Previous Button</Button>
-          <Button onClick={nextStep}>Next Button</Button>
-        </Box>
-      );
-    default:
-      return (
-        <Box style={{ textAlign: "center", padding: "20px 0px 20px 0px" }}>
-          <Heading textStyle="header-large">Intake 💨 3</Heading>
-          <Button onClick={prevStep}>Previous Button</Button>
-        </Box>
-      );
-  }
+        );
+      case 2:
+        return <Heading textStyle="header-large">Intake 💨 2</Heading>;
+      default:
+        return <Heading textStyle="header-large">Intake 💨 3</Heading>;
+    }
+  };
+
+  return (
+    <Box style={{ textAlign: "center", padding: "20px 0px 20px 0px" }}>
+      {renderFormPage(step)}
+      {step > 1 && <Button onClick={prevStep}>Previous Button</Button>}
+      {step < 3 && <Button onClick={nextStep}>Next Button</Button>}
+    </Box>
+  );
 };
 
 export default Intake;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Use the same next/previous buttons for Intake navigation](https://www.notion.so/uwblueprintexecs/Use-the-same-next-previous-buttons-for-Intake-navigation-43bf9e3223c6400fa68fba69fc735b22)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Separated switch statement into its own function
* Using the same prev/next buttons for navigation between forms


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate between the three screens in `/intake`
2. Check that you're able to navigate through all three steps without issue


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* We will need to update the max step in the conditional here as we keep adding screens: https://github.com/uwblueprint/childrens-aid-society/blob/d83219797e9e6affd413d273b216577ea2251bee/frontend/src/components/pages/IntakePage.tsx#L43


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
