### PR TITLE
Add Query for Goals Given Intake ID

### DIFF
--- a/backend/python/app/services/implementations/goal_service.py
+++ b/backend/python/app/services/implementations/goal_service.py
@@ -1,5 +1,6 @@
 from ...models import db
 from ...models.goal import Goal
+from ...models.intake import Intake
 from ...resources.goal_dto import GoalDTO
 from ..interfaces.goal_service import IGoalService
 
@@ -53,7 +54,7 @@ class GoalService(IGoalService):
         try:
             intake = Intake.query.filter_by(id=intake_id).first()
             return [
-                GoalDTO(result.id, result.type, result.goal)
+                GoalDTO(result.id, result.goal, result.type)
                 for result in intake.goals
                 if type == result.type or type is None
             ]

--- a/backend/python/app/services/implementations/goal_service.py
+++ b/backend/python/app/services/implementations/goal_service.py
@@ -48,3 +48,25 @@ class GoalService(IGoalService):
         except Exception as error:
             db.session.rollback()
             raise error
+
+    def get_goals_by_intake(self, intake_id, type=None):
+        try:
+            intake = Intake.query.filter_by(id=intake_id).first()
+            return [                
+                GoalDTO(result.id, result.type, result.goal) 
+                for result in intake.goals if type==result.type or type is None
+            ]
+
+            # return [
+            #     GoalDTO(result.id, result.type, result.goal)
+
+            #     # for result in Goal.query\
+            #     #     .join(intakes_goals)\
+            #     #     .join(Intake)\
+            #     #     .filter((intakes_goals.c.intake_id == intake_id) & (intake_goals.c.goal_id == Goal.id))\
+            #     #     .all()
+            # ]
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+

--- a/backend/python/app/services/implementations/goal_service.py
+++ b/backend/python/app/services/implementations/goal_service.py
@@ -59,15 +59,6 @@ class GoalService(IGoalService):
                 if type == result.type or type is None
             ]
 
-            # return [
-            #     GoalDTO(result.id, result.type, result.goal)
-
-            #     # for result in Goal.query\
-            #     #     .join(intakes_goals)\
-            #     #     .join(Intake)\
-            #     #     .filter((intakes_goals.c.intake_id == intake_id) & (intake_goals.c.goal_id == Goal.id))\
-            #     #     .all()
-            # ]
         except Exception as error:
             self.logger.error(str(error))
             raise error

--- a/backend/python/app/services/implementations/goal_service.py
+++ b/backend/python/app/services/implementations/goal_service.py
@@ -52,9 +52,10 @@ class GoalService(IGoalService):
     def get_goals_by_intake(self, intake_id, type=None):
         try:
             intake = Intake.query.filter_by(id=intake_id).first()
-            return [                
-                GoalDTO(result.id, result.type, result.goal) 
-                for result in intake.goals if type==result.type or type is None
+            return [
+                GoalDTO(result.id, result.type, result.goal)
+                for result in intake.goals
+                if type == result.type or type is None
             ]
 
             # return [
@@ -69,4 +70,3 @@ class GoalService(IGoalService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
-

--- a/backend/python/app/services/interfaces/goal_service.py
+++ b/backend/python/app/services/interfaces/goal_service.py
@@ -51,8 +51,9 @@ class IGoalService(ABC):
         """Get the goals associated with a given intake id;
         If goal type specified, only return goals of given type
         :param intake_id: int of intake ID
+        :param type: string of goal type (LONG_TERM/SHORT_TERM)
         :return: List of goals for given intake
         :rtype: List of GoalDTOs
-        :raises Exception: if goal or intake is invalid
+        :raises Exception: If intake ID does not exist
         """
         pass

--- a/backend/python/app/services/interfaces/goal_service.py
+++ b/backend/python/app/services/interfaces/goal_service.py
@@ -45,4 +45,7 @@ class IGoalService(ABC):
         :rtype: GoalDTO or None
         :raises Exception: if goal type is invalid
         """
+
+    @abstractmethod
+    def get_goals_by_intake(self, intake_id, type=None):
         pass

--- a/backend/python/app/services/interfaces/goal_service.py
+++ b/backend/python/app/services/interfaces/goal_service.py
@@ -48,4 +48,11 @@ class IGoalService(ABC):
 
     @abstractmethod
     def get_goals_by_intake(self, intake_id, type=None):
+        """Get the goals associated with a given intake id;
+        If goal type specified, only return goals of given type
+        :param intake_id: int of intake ID
+        :return: List of goals for given intake
+        :rtype: List of GoalDTOs
+        :raises Exception: if goal or intake is invalid
+        """
         pass

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -1,17 +1,16 @@
 import pytest
-from backend.python.app.resources.goal_dto import GoalDTO
-from backend.python.app.services.implementations.goal_service import GoalService
 from flask import current_app
-
 from app.models import db
 from app.models.goal import Goal
 from app.models.intake import Intake
 from app.resources.goal_dto import GoalDTO
+from app.services.implementations.goal_service import GoalService
 
 
 @pytest.fixture
 def goal_service():
     goal_service = GoalService(current_app.logger)
+    GoalDTO
     seed_database()
     yield goal_service
     Goal.query.delete()

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -1,10 +1,9 @@
+from backend.python.app.services.implementations.goal_service import GoalService
 import pytest
 from flask import current_app
-
 from app.models import db
 from app.models.goal import Goal
 from app.resources.goal_dto import GoalDTO
-from app.services.implementations.goal_service import GoalService
 
 
 @pytest.fixture
@@ -78,3 +77,18 @@ def test_get_all_short_term_goals_success(goal_service):
     goals_db = [entry["goal"] for entry in short_term_goals]
     goals_res = [item.goal for item in res]
     assert set(goals_db) == set(goals_res)
+
+def test_get_long_term_goal_by_intake_id_success():
+    res = goal_service.get_goals_by_intake()
+	# pass
+
+def test_get_short_term_goal_by_intake_id_success():
+	pass
+
+def test_get_goals_by_non_existent_intake_id_raises_error():
+	pass
+
+def test_get_all_goals_success():
+	pass
+
+

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -1,10 +1,12 @@
 import pytest
 from flask import current_app
+
 from app.models import db
 from app.models.goal import Goal
 from app.models.intake import Intake, intakes_goals
 from app.resources.goal_dto import GoalDTO
 from app.services.implementations.goal_service import GoalService
+
 
 @pytest.fixture
 def goal_service():
@@ -32,10 +34,8 @@ DEFAULT_GOALS = [
 # TODO: remove this step when migrations are configured to run against test db
 def seed_database():
     goal_instances = [Goal(**data) for data in DEFAULT_GOALS]
-    # goal_instances = [DEFAULT_GOALS[0]]
     intake_instance = Intake(id=1)
     intake_instance.goals.extend(goal_instances)
-    # db.session.bulk_save_objects(goal_instances)
     db.session.add(intake_instance)
     db.session.commit()
 
@@ -94,7 +94,6 @@ def test_get_long_term_goal_by_intake_id_success(goal_service):
     goals_long_term_db = [goal for goal in DEFAULT_GOALS if goal["type"] == "LONG_TERM"]
     assert len(res) == len(goals_long_term_db)
     assert all(type(item) == GoalDTO for item in res)
-    res_dict = [x.__dict__ for x in res]
     assert all(item.type == "LONG_TERM" for item in res)
 
 
@@ -107,11 +106,6 @@ def test_get_short_term_goal_by_intake_id_success(goal_service):
     assert len(res) == len(goals_short_term_db)
     assert all(type(item) == GoalDTO for item in res)
     assert all(item.type == "SHORT_TERM" for item in res)
-
-
-# def test_get_goals_by_non_existent_intake_id_raises_error():
-#     pass
-
 
 def test_get_all_goals_success(goal_service):
     res = goal_service.get_goals_by_intake(intake_id=1)
@@ -129,6 +123,3 @@ def test_get_all_goals_success(goal_service):
         goals_type_res_counter[item_type] = goals_type_res_counter.get(item_type, 0) + 1
 
     assert goals_type_db_counter == goals_type_res_counter
-
-
-# pass

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -1,11 +1,13 @@
+import pytest
 from backend.python.app.resources.goal_dto import GoalDTO
 from backend.python.app.services.implementations.goal_service import GoalService
-import pytest
 from flask import current_app
+
 from app.models import db
 from app.models.goal import Goal
 from app.models.intake import Intake
 from app.resources.goal_dto import GoalDTO
+
 
 @pytest.fixture
 def goal_service():
@@ -32,6 +34,7 @@ def seed_database():
     intake_instance = Intake(id=1)
     intake_instance.goals.append(goal_instances)
     db.session.bulk_save_objects(intake_instance)
+
 
 def test_get_long_term_goal_fetches_existing_goal(goal_service):
     res = goal_service.get_long_term_goal(
@@ -82,7 +85,7 @@ def test_get_all_short_term_goals_success(goal_service):
 
 
 def test_get_long_term_goal_by_intake_id_success():
-    res = goal_service.get_goals_by_intake(id=1, type= "LONG_TERM")
+    res = goal_service.get_goals_by_intake(id=1, type="LONG_TERM")
     assert type(res) == list
     goals_long_term_db = [goal for goal in DEFAULT_GOALS if goal["type"] == "LONG_TERM"]
     assert len(res) == len(goals_long_term_db)
@@ -91,15 +94,19 @@ def test_get_long_term_goal_by_intake_id_success():
 
 
 def test_get_short_term_goal_by_intake_id_success():
-    res = goal_service.get_goals_by_intake(id=1, type= "SHORT_TERM")
+    res = goal_service.get_goals_by_intake(id=1, type="SHORT_TERM")
     assert type(res) == list
-    goals_short_term_db = [goal for goal in DEFAULT_GOALS if goal["type"] == "SHORT_TERM"]
+    goals_short_term_db = [
+        goal for goal in DEFAULT_GOALS if goal["type"] == "SHORT_TERM"
+    ]
     assert len(res) == len(goals_short_term_db)
     assert all(type(item) == GoalDTO for item in res)
     assert all(item.type == "SHORT_TERM" for item in res)
 
+
 def test_get_goals_by_non_existent_intake_id_raises_error():
-	pass
+    pass
+
 
 def test_get_all_goals_success():
     res = goal_service.get_goals_by_intake(id=1)
@@ -115,6 +122,8 @@ def test_get_all_goals_success():
     for item in res:
         item_type = item.type
         goals_type_res_counter[item_type] = goals_type_res_counter.get(item_type, 0) + 1
- 
+
     assert goals_type_db_counter == goals_type_res_counter
-	# pass
+
+
+# pass

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -82,6 +82,26 @@ def test_get_all_short_term_goals_success(goal_service):
 
 
 def test_get_long_term_goal_by_intake_id_success():
+    res = goal_service.get_goals_by_intake(id=1, type= "LONG_TERM")
+    assert type(res) == list
+    goals_long_term_db = [goal for goal in DEFAULT_GOALS if goal["type"] == "LONG_TERM"]
+    assert len(res) == len(goals_long_term_db)
+    assert all(type(item) == GoalDTO for item in res)
+    assert all(item.type == "LONG_TERM" for item in res)
+
+
+def test_get_short_term_goal_by_intake_id_success():
+    res = goal_service.get_goals_by_intake(id=1, type= "SHORT_TERM")
+    assert type(res) == list
+    goals_short_term_db = [goal for goal in DEFAULT_GOALS if goal["type"] == "SHORT_TERM"]
+    assert len(res) == len(goals_short_term_db)
+    assert all(type(item) == GoalDTO for item in res)
+    assert all(item.type == "SHORT_TERM" for item in res)
+
+def test_get_goals_by_non_existent_intake_id_raises_error():
+	pass
+
+def test_get_all_goals_success():
     res = goal_service.get_goals_by_intake(id=1)
     assert type(res) == list
     assert len(res) == len(DEFAULT_GOALS)
@@ -98,14 +118,3 @@ def test_get_long_term_goal_by_intake_id_success():
  
     assert goals_type_db_counter == goals_type_res_counter
 	# pass
-
-def test_get_short_term_goal_by_intake_id_success():
-	pass
-
-def test_get_goals_by_non_existent_intake_id_raises_error():
-	pass
-
-def test_get_all_goals_success():
-	pass
-
-

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -15,9 +15,7 @@ def goal_service():
     yield goal_service
     db.engine.execute("DELETE FROM intakes_goals;")
     Intake.query.delete()
-    intakes_goals.delete()
     Goal.query.delete()
-    db.session.flush()
 
 
 ## These are fake goals for testing purposes

--- a/backend/python/tests/functional/test_goal_service.py
+++ b/backend/python/tests/functional/test_goal_service.py
@@ -107,6 +107,7 @@ def test_get_short_term_goal_by_intake_id_success(goal_service):
     assert all(type(item) == GoalDTO for item in res)
     assert all(item.type == "SHORT_TERM" for item in res)
 
+
 def test_get_all_goals_success(goal_service):
     res = goal_service.get_goals_by_intake(intake_id=1)
     assert type(res) == list


### PR DESCRIPTION
## Notion ticket link
[Get goals given intake id](https://www.notion.so/uwblueprintexecs/Get-goals-given-intake-id-b4fc9040c686407ea0eef1f63b61e55f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* In Goal service, query intake by ID, then return all goals associated with returned intake


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Verify all python unit tests run accordingly
2.Verify migration applies with no errors by running docker exec -it cas_py_backend /bin/bash -c "flask db upgrade" and then docker exec -it cas_py_backend /bin/bash -c "flask db downgrade"


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Have to add more test cases. Once this is done, verify test coverage is complete


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
