### PR TITLE
[kai/caregiver-route] Add /caregiver route

### DIFF
--- a/backend/python/app/middlewares/validate.py
+++ b/backend/python/app/middlewares/validate.py
@@ -7,10 +7,13 @@ from ..resources.create_user_dto import CreateUserDTO
 from ..resources.register_user_dto import RegisterUserDTO
 from ..resources.update_user_dto import UpdateUserDTO
 
+from ..resources.caregiver_dto import CreateCaregiverDTO
+
 dtos = {
     "CreateUserDTO": CreateUserDTO,
     "RegisterUserDTO": RegisterUserDTO,
     "UpdateUserDTO": UpdateUserDTO,
+    "CreateCaregiverDTO": CreateCaregiverDTO,
 }
 
 

--- a/backend/python/app/middlewares/validate.py
+++ b/backend/python/app/middlewares/validate.py
@@ -3,11 +3,10 @@ from functools import wraps
 
 from flask import jsonify, request
 
+from ..resources.caregiver_dto import CreateCaregiverDTO
 from ..resources.create_user_dto import CreateUserDTO
 from ..resources.register_user_dto import RegisterUserDTO
 from ..resources.update_user_dto import UpdateUserDTO
-
-from ..resources.caregiver_dto import CreateCaregiverDTO
 
 dtos = {
     "CreateUserDTO": CreateUserDTO,

--- a/backend/python/app/rest/__init__.py
+++ b/backend/python/app/rest/__init__.py
@@ -1,18 +1,18 @@
 def init_app(app):
     from . import (
         auth_routes,
+        caregiver_routes,
         child_routes,
         documentation_routes,
         intake_routes,
         user_routes,
         visit_routes,
-        caregiver_routes,
     )
 
-    app.register_blueprint(user_routes.blueprint)
-    app.register_blueprint(intake_routes.blueprint)
     app.register_blueprint(auth_routes.blueprint)
-    app.register_blueprint(documentation_routes.blueprint)
-    app.register_blueprint(visit_routes.blueprint)
-    app.register_blueprint(child_routes.blueprint)
     app.register_blueprint(caregiver_routes.blueprint)
+    app.register_blueprint(child_routes.blueprint)
+    app.register_blueprint(documentation_routes.blueprint)
+    app.register_blueprint(intake_routes.blueprint)
+    app.register_blueprint(user_routes.blueprint)
+    app.register_blueprint(visit_routes.blueprint)

--- a/backend/python/app/rest/__init__.py
+++ b/backend/python/app/rest/__init__.py
@@ -6,6 +6,7 @@ def init_app(app):
         intake_routes,
         user_routes,
         visit_routes,
+        caregiver_routes,
     )
 
     app.register_blueprint(user_routes.blueprint)
@@ -14,3 +15,4 @@ def init_app(app):
     app.register_blueprint(documentation_routes.blueprint)
     app.register_blueprint(visit_routes.blueprint)
     app.register_blueprint(child_routes.blueprint)
+    app.register_blueprint(caregiver_routes.blueprint)

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -23,7 +23,7 @@ def get_all_caregivers():
         return jsonify(error), 400
 
 
-# create caregiver
+# create a caregiver
 @blueprint.route("/", methods=["POST"], strict_slashes=False)
 # @require_authorization_by_role({"Admin"})
 # @validate_request("CreateCaregiverDTO")

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -15,10 +15,8 @@ blueprint = Blueprint("caregiver", __name__, url_prefix="/caregiver")
 # get all caregivers
 @blueprint.route("/", methods=["GET"], strict_slashes=False)
 def get_all_caregivers():
-    # curl -X GET http://localhost:5000/caregiver
     try:
         caregivers = caregiver_service.get_all_caregivers()
         return jsonify(list(map(lambda user: user.__dict__, caregivers))), 200
-        # return jsonify([caregiver.to_dict() for caregiver in caregivers]), 200
     except Exception as error:
         return jsonify(error), 400

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -1,10 +1,8 @@
-import json
-
 from flask import Blueprint, current_app, jsonify, request
 
 from ..middlewares.auth import require_authorization_by_role
 from ..middlewares.validate import validate_request
-from ..resources.caregiver_dto import CaregiverDTO, CreateCaregiverDTO
+from ..resources.caregiver_dto import CreateCaregiverDTO
 from ..services.implementations.caregiver_service import CaregiverService
 
 caregiver_service = CaregiverService(current_app.logger)
@@ -26,7 +24,7 @@ def get_all_caregivers():
 # create a caregiver
 @blueprint.route("/", methods=["POST"], strict_slashes=False)
 # @require_authorization_by_role({"Admin"})
-# @validate_request("CreateCaregiverDTO")
+@validate_request("CreateCaregiverDTO")
 def create_caregiver():
     try:
         caregiver = CreateCaregiverDTO(**request.get_json())

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -18,6 +18,7 @@ def get_all_caregivers():
     # curl -X GET http://localhost:5000/caregiver
     try:
         caregivers = caregiver_service.get_all_caregivers()
-        return jsonify([caregiver.to_dict() for caregiver in caregivers]), 200
+        return jsonify(list(map(lambda user: user.__dict__, caregivers))), 200
+        # return jsonify([caregiver.to_dict() for caregiver in caregivers]), 200
     except Exception as error:
         return jsonify(error), 400

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -12,61 +12,12 @@ caregiver_service = CaregiverService(current_app.logger)
 blueprint = Blueprint("caregiver", __name__, url_prefix="/caregiver")
 
 
-@blueprint.route("/", methods=["POST"], strict_slashes=False)
-@require_authorization_by_role({"Admin"})
-@validate_request("CaregiverDTO")
-def create_caregiver():
+# get all caregivers
+@blueprint.route("/", methods=["GET"], strict_slashes=False)
+def get_all_caregivers():
+    # curl -X GET http://localhost:5000/caregiver
     try:
-        caregiver = CaregiverDTO(**request.get_json())
-        caregiver_service.create_caregiver(caregiver)
-        return jsonify({"message": "Caregiver created successfully"}), 201
-    except Exception as e:
-        error_message = getattr(e, "message", None)
-        return jsonify({"error": (error_message if error_message else str(e))}), 500
-
-
-# only create_caregiver is defined for CaregiverService (for now)
-# @blueprint.route("/<int:caregiver_id>", methods=["PUT"], strict_slashes=False)
-# @require_authorization_by_role({"Admin"})
-# @validate_request("CaregiverDTO")
-# def update_caregiver(caregiver_id):
-#     try:
-#         caregiver = CaregiverDTO(**request.get_json())
-#         caregiver_service.update_caregiver(caregiver_id, caregiver)
-#         return jsonify({"message": "Caregiver updated successfully"}), 200
-#     except Exception as e:
-#         error_message = getattr(e, "message", None)
-#         return jsonify({"error": (error_message if error_message else str(e))}), 500
-
-
-# @blueprint.route("/<int:caregiver_id>", methods=["DELETE"], strict_slashes=False)
-# @require_authorization_by_role({"Admin"})
-# def delete_caregiver(caregiver_id):
-#     try:
-#         caregiver_service.delete_caregiver(caregiver_id)
-#         return jsonify({"message": "Caregiver deleted successfully"}), 200
-#     except Exception as e:
-#         error_message = getattr(e, "message", None)
-#         return jsonify({"error": (error_message if error_message else str(e))}), 500
-
-
-# @blueprint.route("/", methods=["GET"], strict_slashes=False)
-# @require_authorization_by_role({"Admin"})
-# def get_all_caregivers():
-#     try:
-#         caregivers = caregiver_service.get_all_caregivers()
-#         return jsonify(caregivers), 200
-#     except Exception as e:
-#         error_message = getattr(e, "message", None)
-#         return jsonify({"error": (error_message if error_message else str(e))}), 500
-
-
-# @blueprint.route("/<int:caregiver_id>", methods=["GET"], strict_slashes=False)
-# @require_authorization_by_role({"Admin"})
-# def get_caregiver_by_id(caregiver_id):
-#     try:
-#         caregiver = caregiver_service.get_caregiver_by_id(caregiver_id)
-#         return jsonify(caregiver), 200
-#     except Exception as e:
-#         error_message = getattr(e, "message", None)
-#         return jsonify({"error": (error_message if error_message else str(e))}), 500
+        caregivers = caregiver_service.get_all_caregivers()
+        return jsonify([caregiver.to_dict() for caregiver in caregivers]), 200
+    except Exception as error:
+        return jsonify(error), 400

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -14,9 +14,23 @@ blueprint = Blueprint("caregiver", __name__, url_prefix="/caregiver")
 
 # get all caregivers
 @blueprint.route("/", methods=["GET"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
 def get_all_caregivers():
     try:
         caregivers = caregiver_service.get_all_caregivers()
         return jsonify(list(map(lambda user: user.__dict__, caregivers))), 200
+    except Exception as error:
+        return jsonify(error), 400
+
+
+# create caregiver
+@blueprint.route("/", methods=["POST"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
+# @validate_request("CreateCaregiverDTO")
+def create_caregiver():
+    try:
+        caregiver = CreateCaregiverDTO(**request.get_json())
+        new_caregiver = caregiver_service.create_caregiver(caregiver)
+        return jsonify(new_caregiver.__dict__), 201
     except Exception as error:
         return jsonify(error), 400

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -1,0 +1,72 @@
+import json
+
+from flask import Blueprint, current_app, jsonify, request
+
+from ..middlewares.auth import require_authorization_by_role
+from ..middlewares.validate import validate_request
+from ..resources.caregiver_dto import CaregiverDTO, CreateCaregiverDTO
+from ..services.implementations.caregiver_service import CaregiverService
+
+caregiver_service = CaregiverService(current_app.logger)
+
+blueprint = Blueprint("caregiver", __name__, url_prefix="/caregiver")
+
+
+@blueprint.route("/", methods=["POST"], strict_slashes=False)
+@require_authorization_by_role({"Admin"})
+@validate_request("CaregiverDTO")
+def create_caregiver():
+    try:
+        caregiver = CaregiverDTO(**request.get_json())
+        caregiver_service.create_caregiver(caregiver)
+        return jsonify({"message": "Caregiver created successfully"}), 201
+    except Exception as e:
+        error_message = getattr(e, "message", None)
+        return jsonify({"error": (error_message if error_message else str(e))}), 500
+
+
+# only create_caregiver is defined for CaregiverService (for now)
+# @blueprint.route("/<int:caregiver_id>", methods=["PUT"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
+# @validate_request("CaregiverDTO")
+# def update_caregiver(caregiver_id):
+#     try:
+#         caregiver = CaregiverDTO(**request.get_json())
+#         caregiver_service.update_caregiver(caregiver_id, caregiver)
+#         return jsonify({"message": "Caregiver updated successfully"}), 200
+#     except Exception as e:
+#         error_message = getattr(e, "message", None)
+#         return jsonify({"error": (error_message if error_message else str(e))}), 500
+
+
+# @blueprint.route("/<int:caregiver_id>", methods=["DELETE"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
+# def delete_caregiver(caregiver_id):
+#     try:
+#         caregiver_service.delete_caregiver(caregiver_id)
+#         return jsonify({"message": "Caregiver deleted successfully"}), 200
+#     except Exception as e:
+#         error_message = getattr(e, "message", None)
+#         return jsonify({"error": (error_message if error_message else str(e))}), 500
+
+
+# @blueprint.route("/", methods=["GET"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
+# def get_all_caregivers():
+#     try:
+#         caregivers = caregiver_service.get_all_caregivers()
+#         return jsonify(caregivers), 200
+#     except Exception as e:
+#         error_message = getattr(e, "message", None)
+#         return jsonify({"error": (error_message if error_message else str(e))}), 500
+
+
+# @blueprint.route("/<int:caregiver_id>", methods=["GET"], strict_slashes=False)
+# @require_authorization_by_role({"Admin"})
+# def get_caregiver_by_id(caregiver_id):
+#     try:
+#         caregiver = caregiver_service.get_caregiver_by_id(caregiver_id)
+#         return jsonify(caregiver), 200
+#     except Exception as e:
+#         error_message = getattr(e, "message", None)
+#         return jsonify({"error": (error_message if error_message else str(e))}), 500

--- a/backend/python/app/rest/caregiver_routes.py
+++ b/backend/python/app/rest/caregiver_routes.py
@@ -33,4 +33,4 @@ def create_caregiver():
         new_caregiver = caregiver_service.create_caregiver(caregiver)
         return jsonify(new_caregiver.__dict__), 201
     except Exception as error:
-        return jsonify(error), 400
+        return jsonify(str(error)), 400

--- a/backend/python/app/rest/user_routes.py
+++ b/backend/python/app/rest/user_routes.py
@@ -75,8 +75,7 @@ def get_users():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify(
-                        {"error": (error_message if error_message else str(e))}),
+                    jsonify({"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -90,8 +89,7 @@ def get_users():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify(
-                        {"error": (error_message if error_message else str(e))}),
+                    jsonify({"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -151,8 +149,7 @@ def delete_user():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify(
-                        {"error": (error_message if error_message else str(e))}),
+                    jsonify({"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -166,8 +163,7 @@ def delete_user():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify(
-                        {"error": (error_message if error_message else str(e))}),
+                    jsonify({"error": (error_message if error_message else str(e))}),
                     500,
                 )
 

--- a/backend/python/app/rest/user_routes.py
+++ b/backend/python/app/rest/user_routes.py
@@ -34,6 +34,7 @@ DEFAULT_CSV_OPTIONS = {
 
 
 @blueprint.route("/", methods=["GET"], strict_slashes=False)
+@require_authorization_by_role({"User", "Admin"})
 def get_users():
     """
     Get all users, optionally filter by a user_id or email query parameter to retrieve a single user

--- a/backend/python/app/rest/user_routes.py
+++ b/backend/python/app/rest/user_routes.py
@@ -34,7 +34,6 @@ DEFAULT_CSV_OPTIONS = {
 
 
 @blueprint.route("/", methods=["GET"], strict_slashes=False)
-@require_authorization_by_role({"User", "Admin"})
 def get_users():
     """
     Get all users, optionally filter by a user_id or email query parameter to retrieve a single user

--- a/backend/python/app/rest/user_routes.py
+++ b/backend/python/app/rest/user_routes.py
@@ -75,7 +75,8 @@ def get_users():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify({"error": (error_message if error_message else str(e))}),
+                    jsonify(
+                        {"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -89,7 +90,8 @@ def get_users():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify({"error": (error_message if error_message else str(e))}),
+                    jsonify(
+                        {"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -149,7 +151,8 @@ def delete_user():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify({"error": (error_message if error_message else str(e))}),
+                    jsonify(
+                        {"error": (error_message if error_message else str(e))}),
                     500,
                 )
 
@@ -163,7 +166,8 @@ def delete_user():
             except Exception as e:
                 error_message = getattr(e, "message", None)
                 return (
-                    jsonify({"error": (error_message if error_message else str(e))}),
+                    jsonify(
+                        {"error": (error_message if error_message else str(e))}),
                     500,
                 )
 

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -31,9 +31,6 @@ class CaregiverService(ICaregiverService):
 
     def get_all_caregivers(self):
         # FIXME: change this to match spec for actual get caregivers method
-        if not db.engine.dialect.has_table(db.engine, "caregivers"):
-            return []
-
         try:
             caregivers = Caregiver.query.all()
             caregivers_dto = [

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -30,7 +30,6 @@ class CaregiverService(ICaregiverService):
             raise error
 
     def get_all_caregivers(self):
-        # get all caregivers
         if not db.engine.dialect.has_table(db.engine, "caregivers"):
             return []
 

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -30,6 +30,7 @@ class CaregiverService(ICaregiverService):
             raise error
 
     def get_all_caregivers(self):
+        # FIXME: change this to match spec for actual get caregivers method
         if not db.engine.dialect.has_table(db.engine, "caregivers"):
             return []
 

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -35,11 +35,10 @@ class CaregiverService(ICaregiverService):
         if not db.engine.dialect.has_table(db.engine, "caregivers"):
             return []
 
-        # try:
-        caregivers = [x for x in Caregiver.query.all()]
-        caregivers_dict = [x.to_dict() for x in caregivers]
-        caregivers_dto = [CaregiverDTO(**x) for x in caregivers_dict]
-        return caregivers_dto
-        # except Exception as error:
-        #     self.logger.error(str(error))
-        #     raise error
+        try:
+            caregivers = Caregiver.query.all()
+            caregivers_dto = [CaregiverDTO(**x.to_dict()) for x in caregivers]
+            return caregivers_dto
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -30,14 +30,16 @@ class CaregiverService(ICaregiverService):
             self.logger.error(str(error))
             raise error
 
-    # get all caregivers
     def get_all_caregivers(self):
+        # get all caregivers
         if not db.engine.dialect.has_table(db.engine, "caregivers"):
             return []
 
-        try:
-            caregivers = Caregiver.query.all()
-            return [CaregiverDTO(**caregiver.to_dict()) for caregiver in caregivers]
-        except Exception as error:
-            self.logger.error(str(error))
-            raise error
+        # try:
+        caregivers = [x for x in Caregiver.query.all()]
+        caregivers_dict = [x.to_dict() for x in caregivers]
+        caregivers_dto = [CaregiverDTO(**x) for x in caregivers_dict]
+        return caregivers_dto
+        # except Exception as error:
+        #     self.logger.error(str(error))
+        #     raise error

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -11,7 +11,8 @@ class CaregiverService(ICaregiverService):
     def create_caregiver(self, caregiver):
         try:
             if not isinstance(caregiver, CreateCaregiverDTO):
-                raise Exception("Caregiver passed is not of CreateCaregiverDTO type")
+                raise Exception(
+                    "Caregiver passed is not of CreateCaregiverDTO type")
             if not caregiver:
                 raise Exception(
                     "Empty caregiver DTO/None passed to create_caregiver function"
@@ -26,5 +27,17 @@ class CaregiverService(ICaregiverService):
             return CaregiverDTO(**new_caregiver.to_dict())
         except Exception as error:
             db.session.rollback()
+            self.logger.error(str(error))
+            raise error
+
+    # get all caregivers
+    def get_all_caregivers(self):
+        if not db.engine.dialect.has_table(db.engine, "caregivers"):
+            return []
+
+        try:
+            caregivers = Caregiver.query.all()
+            return [CaregiverDTO(**caregiver.to_dict()) for caregiver in caregivers]
+        except Exception as error:
             self.logger.error(str(error))
             raise error

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -36,7 +36,9 @@ class CaregiverService(ICaregiverService):
 
         try:
             caregivers = Caregiver.query.all()
-            caregivers_dto = [CaregiverDTO(**x.to_dict()) for x in caregivers]
+            caregivers_dto = [
+                CaregiverDTO(**caregiver.to_dict()) for caregiver in caregivers
+            ]
             return caregivers_dto
         except Exception as error:
             self.logger.error(str(error))

--- a/backend/python/app/services/implementations/caregiver_service.py
+++ b/backend/python/app/services/implementations/caregiver_service.py
@@ -11,8 +11,7 @@ class CaregiverService(ICaregiverService):
     def create_caregiver(self, caregiver):
         try:
             if not isinstance(caregiver, CreateCaregiverDTO):
-                raise Exception(
-                    "Caregiver passed is not of CreateCaregiverDTO type")
+                raise Exception("Caregiver passed is not of CreateCaregiverDTO type")
             if not caregiver:
                 raise Exception(
                     "Empty caregiver DTO/None passed to create_caregiver function"

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -112,7 +112,7 @@ class UserService(IUserService):
 
     def get_users(self):
         user_dtos = []
-        user_list = [result for result in User.query.all()]
+        user_list = User.query.all()
         for user in user_list:
             user_dict = UserService.__user_to_dict_and_remove_auth_id(user)
             try:

--- a/backend/python/app/services/interfaces/caregiver_service.py
+++ b/backend/python/app/services/interfaces/caregiver_service.py
@@ -17,3 +17,13 @@ class ICaregiverService(ABC):
         :raises Exception: if caregiver creation fails
         """
         pass
+
+    @abstractmethod
+    def get_all_caregivers(self):
+        """
+        Get all caregivers
+        :return: list of caregivers
+        :rtype: list of CaregiverDTO
+        :raises Exception: if get all caregivers fails
+        """
+        pass

--- a/backend/python/tools/db_seed.py
+++ b/backend/python/tools/db_seed.py
@@ -38,9 +38,7 @@ def insert_values(db, table_name: str, column_names: tuple, values: tuple):
     if len_column_names > len_values:
         values += ", " + ", ".join(["NULL"] * (len_column_names - len_values))
 
-    db.engine.execute(
-        f"INSERT INTO {table_name} ({column_names}) VALUES ({values});"
-    )
+    db.engine.execute(f"INSERT INTO {table_name} ({column_names}) VALUES ({values});")
 
 
 # fmt: off

--- a/backend/python/tools/db_seed.py
+++ b/backend/python/tools/db_seed.py
@@ -33,7 +33,7 @@ def insert_values(db, table_name: str, column_names: tuple, values: tuple):
     column_names = tup_to_string_commas(column_names)
     values = tup_to_string_commas_and_quotes(values)
 
-    # equailize the number of values to the number of columns by adding None
+    # equalize the number of values to the number of columns by adding None
     # values to the end of the values tuple
     if len_column_names > len_values:
         values += ", " + ", ".join(["NULL"] * (len_column_names - len_values))
@@ -109,21 +109,22 @@ def insert_test_data():
     for value in values:
         insert_values(db, "caregivers", ("id", "type", "first_name", "last_name", "is_primary", "child_id", "address_id", "relationship_to_child", "phone_number", "cpin_number", "date_of_birth", "special_needs", "name_of_child", "kinship_worker_name", "kinship_worker_ext", "foster_care_coord_name", "foster_care_coord_ext", "limitations_for_access"), value)
 
-    # fmt: on
+# fmt: on
 
-
+# fmt: off
 def clear_rows():
     # delete all rows, but not the tables
-    db.engine.execute("TRUNCATE TABLE children RESTART IDENTITY CASCADE")
-    db.engine.execute("TRUNCATE TABLE caregivers RESTART IDENTITY CASCADE")
-    db.engine.execute("TRUNCATE TABLE users RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE addresses RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE caregivers RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE children RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE children RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE concerns RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE daytime_contacts RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE goals RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE intakes RESTART IDENTITY CASCADE")
-    db.engine.execute(
-        "TRUNCATE TABLE daytime_contacts RESTART IDENTITY CASCADE")
-    db.engine.execute("TRUNCATE TABLE children RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE users RESTART IDENTITY CASCADE")
+
+# fmt: on
 
 
 if __name__ == "__main__":

--- a/backend/python/tools/db_seed.py
+++ b/backend/python/tools/db_seed.py
@@ -45,67 +45,67 @@ def insert_values(db, table_name: str, column_names: tuple, values: tuple):
 def insert_test_data():
     # Users
     values = [
-        (1, "Arya",    "Stark", "auth_id_1", "User",  "WINTERFELL"),
-        (2, "Bran",    "Stark", "auth_id_2", "User",  "WINTERFELL"),
-        (3, "Jon",     "Snow",  "auth_id_3", "Admin", "KNIGHTS_WATCH"),
-        (4, "Samwell", "Tarly", "auth_id_4", "User",  "KNIGHTS_WATCH"),
+        ("Arya",    "Stark", "auth_id_1", "User",  "WINTERFELL"),
+        ("Bran",    "Stark", "auth_id_2", "User",  "WINTERFELL"),
+        ("Jon",     "Snow",  "auth_id_3", "Admin", "KNIGHTS_WATCH"),
+        ("Samwell", "Tarly", "auth_id_4", "User",  "KNIGHTS_WATCH"),
     ]
 
     for value in values:
-        insert_values(db, "users", ("id", "first_name", "last_name", "auth_id", "role", "branch"), value)
+        insert_values(db, "users", ("first_name", "last_name", "auth_id", "role", "branch"), value)
 
     # Addresses
     values = [
-        (1, "27 King''s College Cir", "Toronto",  "M5S 1A1", 43.663, -79.397),
-        (2, "75 University Ave W",    "Waterloo", "N2L 3C5", 43.472, -80.544),
-        (3, "99 University Ave",      "Kingston", "K7L 3N6", 44.229, -76.485),
-        (4, "200 University Ave W",   "Waterloo", "N2L 3G1", 43.472, -80.544),
+        ("27 King''s College Cir", "Toronto",  "M5S 1A1", 43.663, -79.397),
+        ("75 University Ave W",    "Waterloo", "N2L 3C5", 43.472, -80.544),
+        ("99 University Ave",      "Kingston", "K7L 3N6", 44.229, -76.485),
+        ("200 University Ave W",   "Waterloo", "N2L 3G1", 43.472, -80.544),
     ]
 
     for value in values:
-        insert_values(db, "addresses", ("id", "street_address", "city", "postal_code", "latitude", "longitude"), value)
+        insert_values(db, "addresses", ("street_address", "city", "postal_code", "latitude", "longitude"), value)
 
     # Intake
     values = [
-        (1, 1, "2020-01-01", "Smith", "cpin1111", True, True, True, "INTERIM_CARE", "11111", "c11111", True, "FIRST_NATION_REGISTERED", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-01-01", True, "2020-01-01", "2020-01-01", '{"MONDAY", "TUESDAY"}', 1, "10:00", 1, "Denial reason"),
-        (2, 2, "2020-03-27", "Jones", "cpin2222", True, True, True, "FINAL_ORDER_FOR_SOCIETY_CARE", "22222", "c22222", True, "ELIGIBLE_FOR_REGISTRATION", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-03-27", True, "2020-03-27", "2020-03-27", '{"TUESDAY", "MONDAY"}', 1, "03:21:53", 1, "Denial reason"),
-        (3, 3, "2020-04-01", "Williams", "cpin3333", False, True, False, "EXTENDED_SOCIETY_CARE", "33333", "c33333", True, "INUIT", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-04-01", True, "2020-04-01", "2020-04-01", '{"WEDNESDAY", "THURSDAY"}', 1, "23:31:02", 1, "Denial reason"),
-        (4, 4, "2020-04-01", "Brown", "cpin4444", False, False, False, "SUPERVISION_ORDER", "44444", "c44444", True, "METIS", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-05-23", True, "2020-06-01", "2020-04-01", '{"THURSDAY", "WEDNESDAY", "SATURDAY"}', 1, "13:21:02", 1, "Denial reason"),
+        (1, "2020-01-01", "Smith", "cpin1111", True, True, True, "INTERIM_CARE", "11111", "c11111", True, "FIRST_NATION_REGISTERED", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-01-01", True, "2020-01-01", "2020-01-01", '{"MONDAY", "TUESDAY"}', 1, "10:00", 1, "Denial reason"),
+        (2, "2020-03-27", "Jones", "cpin2222", True, True, True, "FINAL_ORDER_FOR_SOCIETY_CARE", "22222", "c22222", True, "ELIGIBLE_FOR_REGISTRATION", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-03-27", True, "2020-03-27", "2020-03-27", '{"TUESDAY", "MONDAY"}', 1, "03:21:53", 1, "Denial reason"),
+        (3, "2020-04-01", "Williams", "cpin3333", False, True, False, "EXTENDED_SOCIETY_CARE", "33333", "c33333", True, "INUIT", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-04-01", True, "2020-04-01", "2020-04-01", '{"WEDNESDAY", "THURSDAY"}', 1, "23:31:02", 1, "Denial reason"),
+        (4, "2020-04-01", "Brown", "cpin4444", False, False, False, "SUPERVISION_ORDER", "44444", "c44444", True, "METIS", "First Nation", "Family strengths", "In person", "Transportation", "Limitations", "2020-05-23", True, "2020-06-01", "2020-04-01", '{"THURSDAY", "WEDNESDAY", "SATURDAY"}', 1, "13:21:02", 1, "Denial reason"),
     ]
 
     for value in values:
-        insert_values(db, "intakes", ("id", "referring_worker_id", "referral_date", "family_name", "cpin_number", "is_investigation", "is_ongoing", "is_court_involved", "court_status", "court_order", "court_order_file", "is_first_nation_heritage", "first_nation_heritage", "first_nation_band", "family_strengths", "access_type", "transportation", "limitations", "case_date", "is_accepted", "date_accepted", "access_start_date", "access_weekday", "access_location_id", "access_time", "lead_access_worker_id", "denial_reason"), value)
+        insert_values(db, "intakes", ("referring_worker_id", "referral_date", "family_name", "cpin_number", "is_investigation", "is_ongoing", "is_court_involved", "court_status", "court_order", "court_order_file", "is_first_nation_heritage", "first_nation_heritage", "first_nation_band", "family_strengths", "access_type", "transportation", "limitations", "case_date", "is_accepted", "date_accepted", "access_start_date", "access_weekday", "access_location_id", "access_time", "lead_access_worker_id", "denial_reason"), value)
 
     # Daytime Contact
     values = [
-        (1, 'Garen', 'Crownguard', 1, '555-555-5555', 'SCHOOL'),
-        (2, 'Shieda', 'Kayn', 2, '555-555-5555', 'DAYCARE'),
-        (3, 'Sarah', 'Fortune', 3, '555-555-5555', 'SCHOOL'),
-        (4, 'Irelia', 'Xan', 4, '555-555-5555', 'DAYCARE'),
+        ('Garen', 'Crownguard', 1, '555-555-5555', 'SCHOOL'),
+        ('Shieda', 'Kayn', 2, '555-555-5555', 'DAYCARE'),
+        ('Sarah', 'Fortune', 3, '555-555-5555', 'SCHOOL'),
+        ('Irelia', 'Xan', 4, '555-555-5555', 'DAYCARE'),
     ]
 
     for value in values:
-        insert_values(db, "daytime_contacts", ("id", "contact_first_name", "contact_last_name", "address_id", "phone_number", "type"), value)
+        insert_values(db, "daytime_contacts", ("contact_first_name", "contact_last_name", "address_id", "phone_number", "type"), value)
 
     # Child
     values = [
-        (1, 1, 'Anya', 'Forger', '2018-01-01', '11111', 1, 1, 'Special needs', True, False),
-        (2, 1, 'Damian', 'Desmond', '2018-03-27', '22222', 2, 2, 'Special needs', True, False),
-        (3, 2, 'Becky', 'Blackbell', '2018-04-01', '33333', 3, 3, 'Special needs', False, True),
-        (4, 3, 'Ewen', 'Egeburg', '2018-04-01', '44444', 4, 4, 'Special needs', False, True),
+        (1, 'Anya', 'Forger', '2018-01-01', '11111', 1, 1, 'Special needs', True, False),
+        (1, 'Damian', 'Desmond', '2018-03-27', '22222', 2, 2, 'Special needs', True, False),
+        (2, 'Becky', 'Blackbell', '2018-04-01', '33333', 3, 3, 'Special needs', False, True),
+        (3, 'Ewen', 'Egeburg', '2018-04-01', '44444', 4, 4, 'Special needs', False, True),
     ]
 
     for value in values:
-        insert_values(db, "children", ("id", "intake_id", "first_name", "last_name", "date_of_birth", "cpin_number", "child_service_worker_id", "daytime_contact_id", "special_needs", "has_kinship_provider", "has_foster_placement"), value)
+        insert_values(db, "children", ("intake_id", "first_name", "last_name", "date_of_birth", "cpin_number", "child_service_worker_id", "daytime_contact_id", "special_needs", "has_kinship_provider", "has_foster_placement"), value)
 
     # Caregivers
     values = [
-        (1, "CAREGIVER", "Yor", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890"),
-        (2, "CAREGIVER", "Loid", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890")
+        ("CAREGIVER", "Yor", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890"),
+        ("CAREGIVER", "Loid", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890")
     ]
 
     for value in values:
-        insert_values(db, "caregivers", ("id", "type", "first_name", "last_name", "is_primary", "child_id", "address_id", "relationship_to_child", "phone_number", "cpin_number", "date_of_birth", "special_needs", "name_of_child", "kinship_worker_name", "kinship_worker_ext", "foster_care_coord_name", "foster_care_coord_ext", "limitations_for_access"), value)
+        insert_values(db, "caregivers", ("type", "first_name", "last_name", "is_primary", "child_id", "address_id", "relationship_to_child", "phone_number", "cpin_number", "date_of_birth", "special_needs", "name_of_child", "kinship_worker_name", "kinship_worker_ext", "foster_care_coord_name", "foster_care_coord_ext", "limitations_for_access"), value)
 
 # fmt: on
 

--- a/backend/python/tools/db_seed.py
+++ b/backend/python/tools/db_seed.py
@@ -27,8 +27,19 @@ def insert_values(db, table_name: str, column_names: tuple, values: tuple):
     """
     Insert values into a table.
     """
+
+    len_column_names = len(column_names)
+    len_values = len(values)
+    column_names = tup_to_string_commas(column_names)
+    values = tup_to_string_commas_and_quotes(values)
+
+    # equailize the number of values to the number of columns by adding None
+    # values to the end of the values tuple
+    if len_column_names > len_values:
+        values += ", " + ", ".join(["NULL"] * (len_column_names - len_values))
+
     db.engine.execute(
-        f"INSERT INTO {table_name} ({tup_to_string_commas(column_names)}) VALUES ({tup_to_string_commas_and_quotes(values)});"
+        f"INSERT INTO {table_name} ({column_names}) VALUES ({values});"
     )
 
 
@@ -44,7 +55,6 @@ def insert_test_data():
 
     for value in values:
         insert_values(db, "users", ("id", "first_name", "last_name", "auth_id", "role", "branch"), value)
-
 
     # Addresses
     values = [
@@ -90,12 +100,22 @@ def insert_test_data():
     for value in values:
         insert_values(db, "children", ("id", "intake_id", "first_name", "last_name", "date_of_birth", "cpin_number", "child_service_worker_id", "daytime_contact_id", "special_needs", "has_kinship_provider", "has_foster_placement"), value)
 
+    # Caregivers
+    values = [
+        (1, "CAREGIVER", "Yor", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890"),
+        (2, "CAREGIVER", "Loid", "Forger", True, 1, 1, "FOSTER_CAREGIVER", "1234567890")
+    ]
+
+    for value in values:
+        insert_values(db, "caregivers", ("id", "type", "first_name", "last_name", "is_primary", "child_id", "address_id", "relationship_to_child", "phone_number", "cpin_number", "date_of_birth", "special_needs", "name_of_child", "kinship_worker_name", "kinship_worker_ext", "foster_care_coord_name", "foster_care_coord_ext", "limitations_for_access"), value)
+
     # fmt: on
 
 
 def clear_rows():
     # delete all rows, but not the tables
     db.engine.execute("TRUNCATE TABLE children RESTART IDENTITY CASCADE")
+    db.engine.execute("TRUNCATE TABLE caregivers RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE users RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE addresses RESTART IDENTITY CASCADE")
     db.engine.execute("TRUNCATE TABLE concerns RESTART IDENTITY CASCADE")


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement POST /caregiver route](https://www.notion.so/uwblueprintexecs/Implement-POST-caregiver-route-7670810e31e64c22bf7a350f32cfe025)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* GET
  * gets all caregivers
  * if the caregiver table does not exist, returns `[]`
* POST
  * adds a caregiver
  * if the request is invalid (e.g. caretaker id already exists, foreign key not found, etc.), then do nothing
 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test GET
1. `docker-compose down --volumes` (after this, the `caregivers` relation does not exist)
2. `docker-compose up`
3. `curl -X GET http://localhost:5000/caregiver` (`[]` is the chosen response when `caregivers` does not exist)
4. `docker exec -it cas_py_backend /bin/bash -c "flask db upgrade"`
5. `docker exec -it cas_py_backend /bin/bash -c "python -m tools.db_seed"`
6. `curl -X GET http://localhost:5000/caregiver` (check that there are 2 caregivers)

## Steps to test POST
- see *"What should reviewers focus on?"* before proceeding
1. `docker-compose down --volumes`
2. `docker-compose up`
3. `docker exec -it cas_py_backend /bin/bash -c "flask db upgrade"`
4. `docker exec -it cas_py_backend /bin/bash -c "python -m tools.db_seed"`
5. `curl -X POST -H "Content-Type: application/json" -d '{"type": "CAREGIVER", "first_name": "John", "last_name": "Doe", "is_primary": true, "child_id": 1, "address_id": 1, "relationship_to_child": "FOSTER_CAREGIVER", "phone_number": "1234567890"}' http://localhost:5000/caregiver/`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* question: the case where the `caretaker` table does not exist and we try to POST is not considered. this is because a valid `caretaker` creation needs a `children` foreign key. and if children exists, caretaker table should exist too. is this ok?
* when testing POST, the tester needs to run the `curl` command 3 times because the first and second runs do not see the existing 2 `caretaker`s created by the seed script. how to fix this?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
