### PR TITLE
Implement ‘Providers’ box within Add Child

### DIFF
--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -51,14 +51,16 @@ const PromptBox = ({
         >
           {buttonText}
         </Button>
-        <Button
-          variant="secondary"
-          colorScheme="gray.600"
-          leftIcon={secondaryButtonIcon}
-          onClick={secondaryOnButtonClick}
-        >
-          {secondaryButtonText}
-        </Button>
+        {secondaryButtonText && (
+          <Button
+            variant="secondary"
+            colorScheme="gray.600"
+            leftIcon={secondaryButtonIcon}
+            onClick={secondaryOnButtonClick}
+          >
+            {secondaryButtonText}
+          </Button>
+        )}
       </HStack>
     </VStack>
   );

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -5,8 +5,11 @@ export type PromptBoxProps = {
   headerText: string;
   descriptionText: string;
   buttonText: string;
-  buttonIcon: ReactElement;
+  buttonIcon?: ReactElement;
   onButtonClick: () => void;
+  secondaryButtonText?: string;
+  secondaryButtonIcon?: ReactElement;
+  secondaryOnButtonClick?: () => void;
 };
 
 const PromptBox = ({
@@ -15,60 +18,10 @@ const PromptBox = ({
   buttonText,
   buttonIcon,
   onButtonClick,
+  secondaryButtonText,
+  secondaryButtonIcon,
+  secondaryOnButtonClick,
 }: PromptBoxProps): React.ReactElement => {
-  return (
-    <VStack
-      bg="gray.50"
-      borderRadius="14px"
-      borderWidth="1px"
-      borderColor="gray.100"
-      align="flex-end"
-      w="full"
-      maxW={816}
-      padding="32px"
-      spacing="16px"
-    >
-      <VStack align="flex-start" w="full" spacing="8px">
-        <Text color="b&w.black" textStyle="title-large">
-          {headerText}
-        </Text>
-        <Text color="gray.600" textStyle="body-large">
-          {descriptionText}
-        </Text>
-      </VStack>
-      <Button
-        variant="secondary"
-        colorScheme="gray.600"
-        leftIcon={buttonIcon}
-        onClick={onButtonClick}
-      >
-        {buttonText}
-      </Button>
-    </VStack>
-  );
-};
-
-export type DoublePromptBoxProps = {
-  headerText: string;
-  descriptionText: string;
-  buttonText1: string;
-  buttonIcon1: ReactElement;
-  onButtonClick1: () => void;
-  buttonText2: string;
-  buttonIcon2: ReactElement;
-  onButtonClick2: () => void;
-};
-
-export const DoublePromptBox = ({
-  headerText,
-  descriptionText,
-  buttonText1,
-  buttonIcon1,
-  onButtonClick1,
-  buttonText2,
-  buttonIcon2,
-  onButtonClick2,
-}: DoublePromptBoxProps): React.ReactElement => {
   return (
     <VStack
       bg="gray.50"
@@ -93,18 +46,18 @@ export const DoublePromptBox = ({
         <Button
           variant="tertiary"
           colorScheme="gray.600"
-          leftIcon={buttonIcon1}
-          onClick={onButtonClick1}
+          leftIcon={buttonIcon}
+          onClick={onButtonClick}
         >
-          {buttonText1}
+          {buttonText}
         </Button>
         <Button
           variant="secondary"
           colorScheme="gray.600"
-          leftIcon={buttonIcon2}
-          onClick={onButtonClick2}
+          leftIcon={secondaryButtonIcon}
+          onClick={secondaryOnButtonClick}
         >
-          {buttonText2}
+          {secondaryButtonText}
         </Button>
       </HStack>
     </VStack>

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { Button, VStack, Text } from "@chakra-ui/react";
+import { Button, VStack, Text, HStack } from "@chakra-ui/react";
 
 export type PromptBoxProps = {
   headerText: string;
@@ -44,6 +44,69 @@ const PromptBox = ({
       >
         {buttonText}
       </Button>
+    </VStack>
+  );
+};
+
+export type DoublePromptBoxProps = {
+  headerText: string;
+  descriptionText: string;
+  buttonText1: string;
+  buttonIcon1: ReactElement;
+  onButtonClick1: () => void;
+  buttonText2: string;
+  buttonIcon2: ReactElement;
+  onButtonClick2: () => void;
+};
+
+export const DoublePromptBox = ({
+  headerText,
+  descriptionText,
+  buttonText1,
+  buttonIcon1,
+  onButtonClick1,
+  buttonText2,
+  buttonIcon2,
+  onButtonClick2,
+}: DoublePromptBoxProps): React.ReactElement => {
+  return (
+    <VStack
+      bg="gray.50"
+      borderRadius="14px"
+      borderWidth="1px"
+      borderColor="gray.100"
+      align="flex-end"
+      w="full"
+      maxW={816}
+      padding="32px"
+      spacing="16px"
+    >
+      <VStack align="flex-start" w="full" spacing="8px">
+        <Text color="b&w.black" textStyle="title-large">
+          {headerText}
+        </Text>
+        <Text color="gray.600" textStyle="body-large">
+          {descriptionText}
+        </Text>
+      </VStack>
+      <HStack>
+        <Button
+          variant="tertiary"
+          colorScheme="gray.600"
+          leftIcon={buttonIcon1}
+          onClick={onButtonClick1}
+        >
+          {buttonText1}
+        </Button>
+        <Button
+          variant="secondary"
+          colorScheme="gray.600"
+          leftIcon={buttonIcon2}
+          onClick={onButtonClick2}
+        >
+          {buttonText2}
+        </Button>
+      </HStack>
     </VStack>
   );
 };

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { UserPlus } from "react-feather";
 import ExistingProvider from "../ExistingProviderModal";
 import NewProviderModal from "../NewProviderModal";
-import { DoublePromptBox } from "../PromptBox";
+import PromptBox from "../PromptBox";
 
 const ChildProviderForm = (): React.ReactElement => {
   const {
@@ -19,15 +19,14 @@ const ChildProviderForm = (): React.ReactElement => {
   return (
     <>
       <VStack padding="100px">
-        <DoublePromptBox
+        <PromptBox
           headerText="Providers"
           descriptionText="At least one provider must be indicated for each child"
-          buttonText1="Add new provider"
-          buttonIcon1={<Icon as={UserPlus} w="16px" h="16px" />}
-          onButtonClick1={onOpenNewProviders}
-          buttonText2="Select providers"
-          buttonIcon2={<Icon as={UserPlus} w="0px" margin="0px" />}
-          onButtonClick2={onOpenExistingProviders}
+          buttonText="Add new provider"
+          buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
+          onButtonClick={onOpenNewProviders}
+          secondaryButtonText="Select providers"
+          secondaryOnButtonClick={onOpenExistingProviders}
         />
         <Box>
           <ExistingProvider

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -1,7 +1,9 @@
-import { Box, Button, useDisclosure } from "@chakra-ui/react";
+import { Box, useDisclosure, Icon, VStack } from "@chakra-ui/react";
 import React from "react";
+import { UserPlus } from "react-feather";
 import ExistingProvider from "../ExistingProviderModal";
 import NewProviderModal from "../NewProviderModal";
+import { DoublePromptBox } from "../PromptBox";
 
 const ChildProviderForm = (): React.ReactElement => {
   const {
@@ -15,18 +17,30 @@ const ChildProviderForm = (): React.ReactElement => {
     onClose: onCloseNewProviders,
   } = useDisclosure();
   return (
-    <Box>
-      <Button onClick={onOpenExistingProviders}>Select providers</Button>
-      <ExistingProvider
-        isOpen={isOpenExistingProviders}
-        onClose={onCloseExistingProviders}
-      />
-      <Button onClick={onOpenNewProviders}>New providers</Button>
-      <NewProviderModal
-        isOpen={isOpenNewProviders}
-        onClose={onCloseNewProviders}
-      />
-    </Box>
+    <>
+      <VStack padding="100px">
+        <DoublePromptBox
+          headerText="Providers"
+          descriptionText="At least one provider must be indicated for each child"
+          buttonText1="Add new provider"
+          buttonIcon1={<Icon as={UserPlus} w="16px" h="16px" />}
+          onButtonClick1={onOpenNewProviders}
+          buttonText2="Select providers"
+          buttonIcon2={<Icon as={UserPlus} w="0px" margin="0px" />}
+          onButtonClick2={onOpenExistingProviders}
+        />
+        <Box>
+          <ExistingProvider
+            isOpen={isOpenExistingProviders}
+            onClose={onCloseExistingProviders}
+          />
+          <NewProviderModal
+            isOpen={isOpenNewProviders}
+            onClose={onCloseNewProviders}
+          />
+        </Box>
+      </VStack>
+    </>
   );
 };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement ‘Providers’ box within Add Child] (https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=fbcf786463c244adbcaf045b7ed8a41e&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Create DoublePromptBox to house two buttons instead of one
![Screenshot 2023-01-22 at 5 49 41 PM](https://user-images.githubusercontent.com/86681988/213944493-6b2b53b4-2bd8-4496-9a73-8b110b3cbfb0.png)



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/intake/add-child and check to make sure providers box is working


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* providers box implementation


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
