### PR TITLE
Add footer with save button to child form

### DIFF
--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -21,7 +21,7 @@ const AddChild = (): React.ReactElement => {
     childBehaviours: "",
   });
 
-  const requiredInfomationMissing : boolean = 
+  const requiredInfomationMissing : boolean =
     !childDetails.childName || 
     !childDetails.cpinFileNumber ||
     !childDetails.dateOfBirth 
@@ -82,7 +82,12 @@ const AddChild = (): React.ReactElement => {
       </VStack>
       {renderChildForm()}
 
-      <Box bg="white" height="87px" display="flex" justifyContent="flex-end" alignItems="center"
+      <Box 
+        bg="white"
+        height="87px"
+        display="flex"
+        justifyContent="flex-end"
+        alignItems="center"
         shadow="0px -4px 12px rgba(226, 225, 236, 0.4), 0px -8px 24px rgba(226, 225, 236, 0.25)"
       >
         <Button

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -25,6 +25,7 @@ const AddChild = (): React.ReactElement => {
     !childDetails.childName || 
     !childDetails.cpinFileNumber ||
     !childDetails.dateOfBirth 
+    // TODO: Check other required fields
 
   const childFormSubmitHandler = () => {
     console.log(childDetails)

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -80,7 +80,8 @@ const AddChild = (): React.ReactElement => {
           onClick={setActiveFormIndex}
         />
       </VStack>
-      {renderChildForm()}
+
+      <Box marginBottom="100px">{renderChildForm()}</Box>
 
       <Box
         bg="white"

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -85,9 +85,12 @@ const AddChild = (): React.ReactElement => {
       <Box
         bg="white"
         height="87px"
+        bottom="0"
+        width="100%"
         display="flex"
         justifyContent="flex-end"
         alignItems="center"
+        position="fixed"
         shadow="0px -4px 12px rgba(226, 225, 236, 0.4), 0px -8px 24px rgba(226, 225, 236, 0.25)"
       >
         <Button
@@ -98,6 +101,7 @@ const AddChild = (): React.ReactElement => {
         >
           Save child information
         </Button>
+        {/* TODO: Add cancel button */}
       </Box>
     </>
   );

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Icon, Text, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { ChevronLeft } from "react-feather";
 import { useHistory } from "react-router-dom";
@@ -11,6 +11,7 @@ import SchoolDaycareForm from "./SchoolDaycareForm";
 const AddChild = (): React.ReactElement => {
   const [activeFormIndex, setActiveFormIndex] = useState(0);
   const history = useHistory();
+
   const [childDetails, setChildDetails] = useState<ChildDetails>({
     childName: "",
     cpinFileNumber: "",
@@ -19,6 +20,16 @@ const AddChild = (): React.ReactElement => {
     specialNeeds: "",
     childBehaviours: "",
   });
+
+  const requiredInfomationMissing : boolean = 
+    !childDetails.childName || 
+    !childDetails.cpinFileNumber ||
+    !childDetails.dateOfBirth 
+
+  const childFormSubmitHandler = () => {
+    console.log(childDetails)
+    // TODO: Do something with the information
+  }
 
   const renderChildForm = () => {
     switch (activeFormIndex) {
@@ -69,7 +80,19 @@ const AddChild = (): React.ReactElement => {
         />
       </VStack>
       {renderChildForm()}
-      {/* TODO: Add footer component */}
+
+      <Box bg="white" height="87px" display="flex" justifyContent="flex-end" alignItems="center"
+        shadow="0px -4px 12px rgba(226, 225, 236, 0.4), 0px -8px 24px rgba(226, 225, 236, 0.25)"
+      >
+        <Button
+          type="submit"
+          mr="96px"
+          disabled={requiredInfomationMissing}
+          onClick={childFormSubmitHandler}
+        >
+          Save child information
+        </Button>
+      </Box>
     </>
   );
 };

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -21,16 +21,16 @@ const AddChild = (): React.ReactElement => {
     childBehaviours: "",
   });
 
-  const requiredInfomationMissing : boolean =
-    !childDetails.childName || 
+  const requiredInfomationMissing: boolean =
+    !childDetails.childName ||
     !childDetails.cpinFileNumber ||
-    !childDetails.dateOfBirth 
-    // TODO: Check other required fields
+    !childDetails.dateOfBirth;
+
+  // TODO: Check other required fields
 
   const childFormSubmitHandler = () => {
-    console.log(childDetails)
     // TODO: Do something with the information
-  }
+  };
 
   const renderChildForm = () => {
     switch (activeFormIndex) {
@@ -82,7 +82,7 @@ const AddChild = (): React.ReactElement => {
       </VStack>
       {renderChildForm()}
 
-      <Box 
+      <Box
         bg="white"
         height="87px"
         display="flex"

--- a/frontend/src/components/intake/child-information/ChildInformationForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildInformationForm.tsx
@@ -47,7 +47,11 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="Enter name of child"
                 icon={<Icon as={User} />}
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, childName: e.target.value})}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setChildDetails({
+                    ...childDetails,
+                    childName: e.target.value
+                  })}
               />
             </Box>
             <Box>
@@ -59,7 +63,11 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="YYYY-MM-DD"
                 icon={<Icon as={Calendar} />}
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, dateOfBirth: e.target.value})}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setChildDetails({
+                    ...childDetails,
+                    dateOfBirth: e.target.value
+                  })}
               />
             </Box>
             <Box>
@@ -73,7 +81,11 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="e.g. 123456789"
                 icon={<Icon as={File} />}
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, cpinFileNumber: e.target.value})}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setChildDetails({
+                    ...childDetails,
+                    cpinFileNumber: e.target.value
+                  })}
               />
             </Box>
             <Box>
@@ -86,7 +98,11 @@ const ChildInformationForm = ({
                 name="workerName"
                 type="string"
                 placeholder="Enter worker name"
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, workerName: e.target.value})}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setChildDetails({
+                    ...childDetails,
+                    workerName: e.target.value
+                  })}
               />
             </Box>
           </SimpleGrid>
@@ -100,7 +116,11 @@ const ChildInformationForm = ({
               name="specialNeeds"
               type="string"
               placeholder="Enter any special needs of the child"
-              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, specialNeeds: e.target.value})}
+              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setChildDetails({
+                  ...childDetails,
+                  specialNeeds: e.target.value
+                })}
             />
           </Box>
           <Box paddingTop="10px">
@@ -113,7 +133,11 @@ const ChildInformationForm = ({
               name="childBehaviours"
               type="string"
               placeholder="Select or enter any behaviours and concerns to note"
-              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, childBehaviours: e.target.value})}
+              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setChildDetails({
+                  ...childDetails,
+                  childBehaviours: e.target.value
+                })}
             />
           </Box>
         </FormControl>

--- a/frontend/src/components/intake/child-information/ChildInformationForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildInformationForm.tsx
@@ -50,8 +50,9 @@ const ChildInformationForm = ({
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    childName: e.target.value
-                  })}
+                    childName: e.target.value,
+                  })
+                }
               />
             </Box>
             <Box>
@@ -66,8 +67,9 @@ const ChildInformationForm = ({
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    dateOfBirth: e.target.value
-                  })}
+                    dateOfBirth: e.target.value,
+                  })
+                }
               />
             </Box>
             <Box>
@@ -84,8 +86,9 @@ const ChildInformationForm = ({
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    cpinFileNumber: e.target.value
-                  })}
+                    cpinFileNumber: e.target.value,
+                  })
+                }
               />
             </Box>
             <Box>
@@ -101,8 +104,9 @@ const ChildInformationForm = ({
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    workerName: e.target.value
-                  })}
+                    workerName: e.target.value,
+                  })
+                }
               />
             </Box>
           </SimpleGrid>
@@ -119,8 +123,9 @@ const ChildInformationForm = ({
               onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setChildDetails({
                   ...childDetails,
-                  specialNeeds: e.target.value
-                })}
+                  specialNeeds: e.target.value,
+                })
+              }
             />
           </Box>
           <Box paddingTop="10px">
@@ -136,8 +141,9 @@ const ChildInformationForm = ({
               onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setChildDetails({
                   ...childDetails,
-                  childBehaviours: e.target.value
-                })}
+                  childBehaviours: e.target.value,
+                })
+              }
             />
           </Box>
         </FormControl>

--- a/frontend/src/components/intake/child-information/ChildInformationForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildInformationForm.tsx
@@ -47,6 +47,7 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="Enter name of child"
                 icon={<Icon as={User} />}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, childName: e.target.value})}
               />
             </Box>
             <Box>
@@ -58,6 +59,7 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="YYYY-MM-DD"
                 icon={<Icon as={Calendar} />}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, dateOfBirth: e.target.value})}
               />
             </Box>
             <Box>
@@ -71,6 +73,7 @@ const ChildInformationForm = ({
                 type="string"
                 placeholder="e.g. 123456789"
                 icon={<Icon as={File} />}
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, cpinFileNumber: e.target.value})}
               />
             </Box>
             <Box>
@@ -83,6 +86,7 @@ const ChildInformationForm = ({
                 name="workerName"
                 type="string"
                 placeholder="Enter worker name"
+                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, workerName: e.target.value})}
               />
             </Box>
           </SimpleGrid>
@@ -96,6 +100,7 @@ const ChildInformationForm = ({
               name="specialNeeds"
               type="string"
               placeholder="Enter any special needs of the child"
+              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, specialNeeds: e.target.value})}
             />
           </Box>
           <Box paddingTop="10px">
@@ -108,12 +113,11 @@ const ChildInformationForm = ({
               name="childBehaviours"
               type="string"
               placeholder="Select or enter any behaviours and concerns to note"
+              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) => setChildDetails({...childDetails, childBehaviours: e.target.value})}
             />
           </Box>
         </FormControl>
       </Form>
-
-      {/* TODO: trigger on submit when save child information button is clicked */}
     </Formik>
   );
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add ‘Save Child Information’ button to Add Child flow](https://www.notion.so/uwblueprintexecs/Add-Save-Child-Information-button-to-Add-Child-flow-f6130403d9fe4e71ac2e490ba2ce40f1)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Added footer to `AddChildPage.tsx` with save button since it makes more sense to have on save button instead of three (one on each form page). Also the Figma said "Primary button is disabled until all required fields across the three pages have valid inputs. "
- Added onKeyUp listeners to the Fields on the first form that update the state. This is useful for the future if format validation is implemented.
- Added check for required fields for the child Information. The other two forms are incomplete so did not add checks for that but left comments.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the form `http://localhost:3000/intake/add-child`
2. Fill in the form
3. After filling in name, cpin, and DOB, the save information button should become clickable
4. Deleting any of the above fields disables it


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
*  `AddChildPage.tsx` -> footer
*   `ChildInformationForm.tsx` -> added onKeyUp listeners 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
