### PR TITLE
Render Individual’s details through PromptBox

### DIFF
--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, VStack, Icon, useDisclosure } from "@chakra-ui/react";
 import { UserPlus } from "react-feather";
 import { useHistory } from "react-router-dom";
-import PromptBox from "./PromptBox";
+import PromptBox, { IndividualDetailsOverview } from "./PromptBox";
 import { ADD_CHILD_PAGE } from "../../constants/Routes";
 import NewCaregiverModal from "./NewCaregiverModal";
 
@@ -23,6 +23,10 @@ const IndividualDetailsEntry = ({
     onClose: onCloseAddCaregivers,
   } = useDisclosure();
 
+  const testCaregivers: [IndividualDetailsOverview] = [
+    { firstName: "First", lastName: "Last", fileNumber: "2347892349" },
+  ];
+
   return (
     <React.Fragment key="IndividualDetailsEntry">
       <VStack padding="32px" spacing="24px">
@@ -41,6 +45,7 @@ const IndividualDetailsEntry = ({
           buttonText="Add caregiver"
           buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           onButtonClick={onOpenAddCaregivers}
+          individualDetails={testCaregivers}
         />
         <NewCaregiverModal
           isOpen={isOpenAddCaregivers}

--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, VStack, Icon, useDisclosure } from "@chakra-ui/react";
 import { UserPlus } from "react-feather";
 import { useHistory } from "react-router-dom";
-import PromptBox, { IndividualDetailsOverview } from "./PromptBox";
+import PromptBox from "./PromptBox";
 import { ADD_CHILD_PAGE } from "../../constants/Routes";
 import NewCaregiverModal from "./NewCaregiverModal";
 
@@ -23,10 +23,6 @@ const IndividualDetailsEntry = ({
     onClose: onCloseAddCaregivers,
   } = useDisclosure();
 
-  const testCaregivers: [IndividualDetailsOverview] = [
-    { firstName: "First", lastName: "Last", fileNumber: "2347892349" },
-  ];
-
   return (
     <React.Fragment key="IndividualDetailsEntry">
       <VStack padding="32px" spacing="24px">
@@ -45,7 +41,6 @@ const IndividualDetailsEntry = ({
           buttonText="Add caregiver"
           buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           onButtonClick={onOpenAddCaregivers}
-          individualDetails={testCaregivers}
         />
         <NewCaregiverModal
           isOpen={isOpenAddCaregivers}

--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, VStack, Icon, useDisclosure } from "@chakra-ui/react";
 import { UserPlus } from "react-feather";
 import { useHistory } from "react-router-dom";
-import PromptBox, { IndividualDetailsOverview } from "./PromptBox";
+import PromptBox from "./PromptBox";
 import { ADD_CHILD_PAGE } from "../../constants/Routes";
 import NewCaregiverModal from "./NewCaregiverModal";
 
@@ -23,11 +23,6 @@ const IndividualDetailsEntry = ({
     onClose: onCloseAddCaregivers,
   } = useDisclosure();
 
-  const testCaregivers: IndividualDetailsOverview[] = [
-    { firstName: "first", lastName: "last", fileNumber: "1231321312321" },
-    { firstName: "John", lastName: "Doe", fileNumber: "0123456789" },
-  ];
-
   return (
     <React.Fragment key="IndividualDetailsEntry">
       <VStack padding="32px" spacing="24px">
@@ -46,7 +41,6 @@ const IndividualDetailsEntry = ({
           buttonText="Add caregiver"
           buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           onButtonClick={onOpenAddCaregivers}
-          individualDetails={testCaregivers}
         />
         <NewCaregiverModal
           isOpen={isOpenAddCaregivers}

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -18,7 +18,7 @@ export type PromptBoxProps = {
   secondaryButtonText?: string;
   secondaryButtonIcon?: ReactElement;
   secondaryOnButtonClick?: () => void;
-  individualDetails?: [IndividualDetailsOverview];
+  individualDetails?: IndividualDetailsOverview[];
 };
 
 const PromptBox = ({
@@ -97,17 +97,9 @@ const PromptBox = ({
         )}
       </VStack>
       <HStack>
-        <Button
-          variant="tertiary"
-          colorScheme="gray.600"
-          leftIcon={buttonIcon}
-          onClick={onButtonClick}
-        >
-          {buttonText}
-        </Button>
         {secondaryButtonText && (
           <Button
-            variant="secondary"
+            variant="tertiary"
             colorScheme="gray.600"
             leftIcon={secondaryButtonIcon}
             onClick={secondaryOnButtonClick}
@@ -115,6 +107,14 @@ const PromptBox = ({
             {secondaryButtonText}
           </Button>
         )}
+        <Button
+          variant="secondary"
+          colorScheme="gray.600"
+          leftIcon={buttonIcon}
+          onClick={onButtonClick}
+        >
+          {buttonText}
+        </Button>
       </HStack>
     </VStack>
   );

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -51,14 +51,16 @@ const PromptBox = ({
         >
           {buttonText}
         </Button>
-        <Button
-          variant="secondary"
-          colorScheme="gray.600"
-          leftIcon={secondaryButtonIcon}
-          onClick={secondaryOnButtonClick}
-        >
-          {secondaryButtonText}
-        </Button>
+        {secondaryButtonText && (
+          <Button
+            variant="secondary"
+            colorScheme="gray.600"
+            leftIcon={secondaryButtonIcon}
+            onClick={secondaryOnButtonClick}
+          >
+            {secondaryButtonText}
+          </Button>
+        )}
       </HStack>
     </VStack>
   );

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -5,8 +5,11 @@ export type PromptBoxProps = {
   headerText: string;
   descriptionText: string;
   buttonText: string;
-  buttonIcon: ReactElement;
+  buttonIcon?: ReactElement;
   onButtonClick: () => void;
+  secondaryButtonText?: string;
+  secondaryButtonIcon?: ReactElement;
+  secondaryOnButtonClick?: () => void;
 };
 
 const PromptBox = ({
@@ -15,60 +18,10 @@ const PromptBox = ({
   buttonText,
   buttonIcon,
   onButtonClick,
+  secondaryButtonText,
+  secondaryButtonIcon,
+  secondaryOnButtonClick,
 }: PromptBoxProps): React.ReactElement => {
-  return (
-    <VStack
-      bg="gray.50"
-      borderRadius="14px"
-      borderWidth="1px"
-      borderColor="gray.100"
-      align="flex-end"
-      w="full"
-      maxW={816}
-      padding="32px"
-      spacing="16px"
-    >
-      <VStack align="flex-start" w="full" spacing="8px">
-        <Text color="b&w.black" textStyle="title-large">
-          {headerText}
-        </Text>
-        <Text color="gray.600" textStyle="body-large">
-          {descriptionText}
-        </Text>
-      </VStack>
-      <Button
-        variant="secondary"
-        colorScheme="gray.600"
-        leftIcon={buttonIcon}
-        onClick={onButtonClick}
-      >
-        {buttonText}
-      </Button>
-    </VStack>
-  );
-};
-
-export type DoublePromptBoxProps = {
-  headerText: string;
-  descriptionText: string;
-  buttonText1: string;
-  buttonIcon1: ReactElement;
-  onButtonClick1: () => void;
-  buttonText2: string;
-  buttonIcon2: ReactElement;
-  onButtonClick2: () => void;
-};
-
-export const DoublePromptBox = ({
-  headerText,
-  descriptionText,
-  buttonText1,
-  buttonIcon1,
-  onButtonClick1,
-  buttonText2,
-  buttonIcon2,
-  onButtonClick2,
-}: DoublePromptBoxProps): React.ReactElement => {
   return (
     <VStack
       bg="gray.50"
@@ -93,18 +46,18 @@ export const DoublePromptBox = ({
         <Button
           variant="tertiary"
           colorScheme="gray.600"
-          leftIcon={buttonIcon1}
-          onClick={onButtonClick1}
+          leftIcon={buttonIcon}
+          onClick={onButtonClick}
         >
-          {buttonText1}
+          {buttonText}
         </Button>
         <Button
           variant="secondary"
           colorScheme="gray.600"
-          leftIcon={buttonIcon2}
-          onClick={onButtonClick2}
+          leftIcon={secondaryButtonIcon}
+          onClick={secondaryOnButtonClick}
         >
-          {buttonText2}
+          {secondaryButtonText}
         </Button>
       </HStack>
     </VStack>

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { Button, VStack, Text } from "@chakra-ui/react";
+import { Button, VStack, Text, HStack } from "@chakra-ui/react";
 
 export type PromptBoxProps = {
   headerText: string;
@@ -44,6 +44,69 @@ const PromptBox = ({
       >
         {buttonText}
       </Button>
+    </VStack>
+  );
+};
+
+export type DoublePromptBoxProps = {
+  headerText: string;
+  descriptionText: string;
+  buttonText1: string;
+  buttonIcon1: ReactElement;
+  onButtonClick1: () => void;
+  buttonText2: string;
+  buttonIcon2: ReactElement;
+  onButtonClick2: () => void;
+};
+
+export const DoublePromptBox = ({
+  headerText,
+  descriptionText,
+  buttonText1,
+  buttonIcon1,
+  onButtonClick1,
+  buttonText2,
+  buttonIcon2,
+  onButtonClick2,
+}: DoublePromptBoxProps): React.ReactElement => {
+  return (
+    <VStack
+      bg="gray.50"
+      borderRadius="14px"
+      borderWidth="1px"
+      borderColor="gray.100"
+      align="flex-end"
+      w="full"
+      maxW={816}
+      padding="32px"
+      spacing="16px"
+    >
+      <VStack align="flex-start" w="full" spacing="8px">
+        <Text color="b&w.black" textStyle="title-large">
+          {headerText}
+        </Text>
+        <Text color="gray.600" textStyle="body-large">
+          {descriptionText}
+        </Text>
+      </VStack>
+      <HStack>
+        <Button
+          variant="tertiary"
+          colorScheme="gray.600"
+          leftIcon={buttonIcon1}
+          onClick={onButtonClick1}
+        >
+          {buttonText1}
+        </Button>
+        <Button
+          variant="secondary"
+          colorScheme="gray.600"
+          leftIcon={buttonIcon2}
+          onClick={onButtonClick2}
+        >
+          {buttonText2}
+        </Button>
+      </HStack>
     </VStack>
   );
 };

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import { Button, VStack, Text, HStack, Icon, Divider } from "@chakra-ui/react";
 import { useHistory } from "react-router-dom";
-import { ArrowRight } from "react-feather";
+import { ArrowRight, Trash } from "react-feather";
 
 export type IndividualDetailsOverview = {
   firstName: string;
@@ -55,9 +55,21 @@ const PromptBox = ({
             <VStack key={i} w="full">
               <HStack w="full">
                 <VStack align="flex-start" w="full" spacing="0px">
-                  <Text textStyle="title-small">
-                    {indiv.firstName} {indiv.lastName}
-                  </Text>
+                  <HStack>
+                    <Text textStyle="title-small">
+                      {indiv.firstName} {indiv.lastName}
+                    </Text>
+                    <Icon
+                      onClick={() => {
+                        history.goBack();
+                        // TODO: deletes details, history.goBack() is just a placeholder, replace when ready
+                      }}
+                      as={Trash}
+                      h="16px"
+                      color="grey.600"
+                      cursor="pointer"
+                    />
+                  </HStack>
                   <Text color="gray.600" textStyle="body-medium">
                     {indiv.fileNumber}
                   </Text>
@@ -68,7 +80,7 @@ const PromptBox = ({
                   variant="link"
                   onClick={() => {
                     history.goBack();
-                    // TODO
+                    // TODO: implement view and edit details button, history.goBack() is just a placeholder, replace when ready
                   }}
                   rightIcon={<Icon as={ArrowRight} h="16px" />}
                 >

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -77,7 +77,7 @@ const PromptBox = ({
                 <Button
                   color="blue.300"
                   textStyle="button-small"
-                  variant="link"
+                  variant="tertiary"
                   onClick={() => {
                     history.goBack();
                     // TODO: implement view and edit details button, history.goBack() is just a placeholder, replace when ready

--- a/frontend/src/components/intake/PromptBox.tsx
+++ b/frontend/src/components/intake/PromptBox.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement } from "react";
-import { Button, VStack, Text, HStack } from "@chakra-ui/react";
+import { Button, VStack, Text, HStack, Icon, Divider } from "@chakra-ui/react";
+import { useHistory } from "react-router-dom";
+import { ArrowRight } from "react-feather";
+
+export type IndividualDetailsOverview = {
+  firstName: string;
+  lastName: string;
+  fileNumber: string;
+};
 
 export type PromptBoxProps = {
   headerText: string;
@@ -10,6 +18,7 @@ export type PromptBoxProps = {
   secondaryButtonText?: string;
   secondaryButtonIcon?: ReactElement;
   secondaryOnButtonClick?: () => void;
+  individualDetails?: [IndividualDetailsOverview];
 };
 
 const PromptBox = ({
@@ -21,7 +30,10 @@ const PromptBox = ({
   secondaryButtonText,
   secondaryButtonIcon,
   secondaryOnButtonClick,
+  individualDetails,
 }: PromptBoxProps): React.ReactElement => {
+  const history = useHistory();
+
   return (
     <VStack
       bg="gray.50"
@@ -38,9 +50,39 @@ const PromptBox = ({
         <Text color="b&w.black" textStyle="title-large">
           {headerText}
         </Text>
-        <Text color="gray.600" textStyle="body-large">
-          {descriptionText}
-        </Text>
+        {individualDetails ? (
+          individualDetails.map((indiv, i) => (
+            <VStack key={i} w="full">
+              <HStack w="full">
+                <VStack align="flex-start" w="full" spacing="0px">
+                  <Text textStyle="title-small">
+                    {indiv.firstName} {indiv.lastName}
+                  </Text>
+                  <Text color="gray.600" textStyle="body-medium">
+                    {indiv.fileNumber}
+                  </Text>
+                </VStack>
+                <Button
+                  color="blue.300"
+                  textStyle="button-small"
+                  variant="link"
+                  onClick={() => {
+                    history.goBack();
+                    // TODO
+                  }}
+                  rightIcon={<Icon as={ArrowRight} h="16px" />}
+                >
+                  View and edit details
+                </Button>
+              </HStack>
+              <Divider orientation="horizontal" w="full" />
+            </VStack>
+          ))
+        ) : (
+          <Text color="gray.600" textStyle="body-large">
+            {descriptionText}
+          </Text>
+        )}
       </VStack>
       <HStack>
         <Button

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -23,10 +23,10 @@ const ChildProviderForm = (): React.ReactElement => {
         <PromptBox
           headerText="Providers"
           descriptionText="At least one provider must be indicated for each child"
-          buttonText="Add new provider"
+          buttonText="Select providers"
           buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           onButtonClick={onOpenNewProviders}
-          secondaryButtonText="Select providers"
+          secondaryButtonText="Add new provider"
           secondaryOnButtonClick={onOpenExistingProviders}
         />
         <Box>

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { UserPlus } from "react-feather";
 import ExistingProvider from "../ExistingProviderModal";
 import NewProviderModal from "../NewProviderModal";
-import { DoublePromptBox } from "../PromptBox";
+import PromptBox from "../PromptBox";
 
 const ChildProviderForm = (): React.ReactElement => {
   const {
@@ -19,15 +19,14 @@ const ChildProviderForm = (): React.ReactElement => {
   return (
     <>
       <VStack padding="100px">
-        <DoublePromptBox
+        <PromptBox
           headerText="Providers"
           descriptionText="At least one provider must be indicated for each child"
-          buttonText1="Add new provider"
-          buttonIcon1={<Icon as={UserPlus} w="16px" h="16px" />}
-          onButtonClick1={onOpenNewProviders}
-          buttonText2="Select providers"
-          buttonIcon2={<Icon as={UserPlus} w="0px" margin="0px" />}
-          onButtonClick2={onOpenExistingProviders}
+          buttonText="Add new provider"
+          buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
+          onButtonClick={onOpenNewProviders}
+          secondaryButtonText="Select providers"
+          secondaryOnButtonClick={onOpenExistingProviders}
         />
         <Box>
           <ExistingProvider

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -16,6 +16,7 @@ const ChildProviderForm = (): React.ReactElement => {
     isOpen: isOpenNewProviders,
     onClose: onCloseNewProviders,
   } = useDisclosure();
+
   return (
     <>
       <VStack padding="100px">

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -1,7 +1,9 @@
-import { Box, Button, useDisclosure } from "@chakra-ui/react";
+import { Box, useDisclosure, Icon, VStack } from "@chakra-ui/react";
 import React from "react";
+import { UserPlus } from "react-feather";
 import ExistingProvider from "../ExistingProviderModal";
 import NewProviderModal from "../NewProviderModal";
+import { DoublePromptBox } from "../PromptBox";
 
 const ChildProviderForm = (): React.ReactElement => {
   const {
@@ -15,18 +17,30 @@ const ChildProviderForm = (): React.ReactElement => {
     onClose: onCloseNewProviders,
   } = useDisclosure();
   return (
-    <Box>
-      <Button onClick={onOpenExistingProviders}>Select providers</Button>
-      <ExistingProvider
-        isOpen={isOpenExistingProviders}
-        onClose={onCloseExistingProviders}
-      />
-      <Button onClick={onOpenNewProviders}>New providers</Button>
-      <NewProviderModal
-        isOpen={isOpenNewProviders}
-        onClose={onCloseNewProviders}
-      />
-    </Box>
+    <>
+      <VStack padding="100px">
+        <DoublePromptBox
+          headerText="Providers"
+          descriptionText="At least one provider must be indicated for each child"
+          buttonText1="Add new provider"
+          buttonIcon1={<Icon as={UserPlus} w="16px" h="16px" />}
+          onButtonClick1={onOpenNewProviders}
+          buttonText2="Select providers"
+          buttonIcon2={<Icon as={UserPlus} w="0px" margin="0px" />}
+          onButtonClick2={onOpenExistingProviders}
+        />
+        <Box>
+          <ExistingProvider
+            isOpen={isOpenExistingProviders}
+            onClose={onCloseExistingProviders}
+          />
+          <NewProviderModal
+            isOpen={isOpenNewProviders}
+            onClose={onCloseNewProviders}
+          />
+        </Box>
+      </VStack>
+    </>
   );
 };
 

--- a/frontend/src/components/intake/child-information/ChildProviderForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildProviderForm.tsx
@@ -24,9 +24,9 @@ const ChildProviderForm = (): React.ReactElement => {
           headerText="Providers"
           descriptionText="At least one provider must be indicated for each child"
           buttonText="Select providers"
-          buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           onButtonClick={onOpenNewProviders}
           secondaryButtonText="Add new provider"
+          secondaryButtonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
           secondaryOnButtonClick={onOpenExistingProviders}
         />
         <Box>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Render Individual’s details through PromptBox](https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=b4a8e66b22204b89a491ab4f47f839ae&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add conditional rendering of individual information in PromptBox component
* Add unimplemented `Delete` and `View and edit details` buttons along with each generated piece of information


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

![Screenshot 2023-01-25 at 7 58 27 PM](https://user-images.githubusercontent.com/86681988/214731021-c40f5937-0dca-4489-8624-214d2afdb01d.png)

## Steps to test
1. Go to any file which uses the PromptBox component (ie. `IndividualDetailsEntry.tsx`)
2. `import { IndividualDetailsOverview }`
3. Declare a test variable 
```
const testCaregivers: IndividualDetailsOverview[] = [
	{firstName: "", secondName: "", fileNumber: ""},
	{and so on},
]
```
4. Add the `individualDetails` prop with `testCaregivers` to the `PromptBox` of your choice


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Making sure information loads conditionally
* Styling aligns with Figma implementation


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
