### PR TITLE
Implement ‘Edit’ button function in Review Case page

### DIFF
--- a/frontend/src/components/intake/IndividualDetails.tsx
+++ b/frontend/src/components/intake/IndividualDetails.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 import { Button, VStack, Text, HStack, Icon, Divider } from "@chakra-ui/react";
-import { Edit2, ArrowRight } from "react-feather";
+import { ArrowRight } from "react-feather";
 import { useHistory } from "react-router-dom";
 import { IndividualDetailsOverview } from "./PromptBox";
 
 type IndividualDetailsProps = {
-  title: string;
   childrenDetails: IndividualDetailsOverview[];
   caregiverDetails: IndividualDetailsOverview[];
 };
 
 const IndividualDetails = ({
-  title,
   childrenDetails,
   caregiverDetails,
 }: IndividualDetailsProps): React.ReactElement => {

--- a/frontend/src/components/intake/IndividualDetails.tsx
+++ b/frontend/src/components/intake/IndividualDetails.tsx
@@ -19,19 +19,7 @@ const IndividualDetails = ({
 
   return (
     <>
-      <VStack padding="32px" align="flex-start" spacing="16px">
-        <HStack w="full" display="flex" justifyContent="space-between">
-          <Text color="b&w.black" textStyle="header-large">
-            {title}
-          </Text>
-          <Button
-            textStyle="button-medium"
-            variant="primary"
-            rightIcon={<Icon as={Edit2} h="16px" />}
-          >
-            Edit {/* TODO: implement edit button */}
-          </Button>
-        </HStack>
+      <VStack paddingY="32px" align="flex-start" spacing="16px">
         <Text
           color="blue.500"
           textStyle="label"
@@ -69,7 +57,7 @@ const IndividualDetails = ({
           </VStack>
         ))}
       </VStack>
-      <VStack padding="32px" align="flex-start" spacing="16px">
+      <VStack paddingY="32px" align="flex-start" spacing="16px">
         <Text
           color="blue.500"
           textStyle="label"

--- a/frontend/src/components/intake/ReviewCaseForm.tsx
+++ b/frontend/src/components/intake/ReviewCaseForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, HStack, Text, Icon, Stack, Box } from "@chakra-ui/react";
+import { Button, HStack, Icon, Stack, Text } from "@chakra-ui/react";
 import { Edit2 } from "react-feather";
 import IndividualDetails from "./IndividualDetails";
 import ReferralForm, { ReferralDetails } from "./ReferralForm";
@@ -18,6 +18,7 @@ type ReviewFormProps = {
   nextStep: () => void;
   prevStep: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  setReviewHeader: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const ReviewForm = ({
@@ -30,6 +31,7 @@ const ReviewForm = ({
   nextStep,
   prevStep,
   setStep,
+  setReviewHeader,
 }: ReviewFormProps): React.ReactElement => {
   const onNextStep = () => {
     nextStep(); // TODO: Add functionality for nextStep (Currently we pass in empty nextStep() prop)
@@ -46,8 +48,12 @@ const ReviewForm = ({
             textStyle="button-medium"
             variant="primary"
             rightIcon={<Icon as={Edit2} h="16px" />}
+            onClick={() => {
+              setStep(IntakeSteps.CASE_REFERRAL);
+              setReviewHeader(true);
+            }}
           >
-            Edit {/* TODO: implement edit button */}
+            Edit
           </Button>
         </HStack>
         <ReferralForm
@@ -70,8 +76,12 @@ const ReviewForm = ({
             textStyle="button-medium"
             variant="primary"
             rightIcon={<Icon as={Edit2} h="16px" />}
+            onClick={() => {
+              setStep(IntakeSteps.COURT_INFORMATION);
+              setReviewHeader(true);
+            }}
           >
-            Edit {/* TODO: implement edit button */}
+            Edit
           </Button>
         </HStack>
         <CourtInformationForm
@@ -85,23 +95,45 @@ const ReviewForm = ({
         />
       </Stack>
 
-      <IndividualDetails
-        title="Individual details"
-        childrenDetails={[]}
-        caregiverDetails={[]}
-      />
-
       <Stack padding="32px" spacing="16px">
         <HStack w="full" display="flex" justifyContent="space-between">
           <Text color="b&w.black" textStyle="header-large">
-            Program Details
+            Individual details
           </Text>
           <Button
             textStyle="button-medium"
             variant="primary"
             rightIcon={<Icon as={Edit2} h="16px" />}
+            onClick={() => {
+              setStep(IntakeSteps.INDIVIDUAL_DETAILS);
+              setReviewHeader(true);
+            }}
           >
-            Edit {/* TODO: implement edit button */}
+            Edit
+          </Button>
+        </HStack>
+        <IndividualDetails
+          title="Individual details"
+          childrenDetails={[]}
+          caregiverDetails={[]}
+        />
+      </Stack>
+
+      <Stack padding="32px" spacing="16px">
+        <HStack w="full" display="flex" justifyContent="space-between">
+          <Text color="b&w.black" textStyle="header-large">
+            Program details
+          </Text>
+          <Button
+            textStyle="button-medium"
+            variant="primary"
+            rightIcon={<Icon as={Edit2} h="16px" />}
+            onClick={() => {
+              setStep(IntakeSteps.PROGRAM_DETAILS);
+              setReviewHeader(true);
+            }}
+          >
+            Edit
           </Button>
         </HStack>
         <ProgramForm
@@ -122,15 +154,6 @@ const ReviewForm = ({
         registrationLoading={false}
         nextStepCallBack={onNextStep}
       />
-      <Box>
-        <Button
-          onClick={() => {
-            prevStep();
-          }}
-        >
-          Previous Button
-        </Button>
-      </Box>
     </>
   );
 };

--- a/frontend/src/components/intake/ReviewCaseForm.tsx
+++ b/frontend/src/components/intake/ReviewCaseForm.tsx
@@ -16,7 +16,6 @@ type ReviewFormProps = {
   programDetails: ProgramDetails;
   setProgramDetails: React.Dispatch<React.SetStateAction<ProgramDetails>>;
   nextStep: () => void;
-  prevStep: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   setReviewHeader: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -29,7 +28,6 @@ const ReviewForm = ({
   programDetails,
   setProgramDetails,
   nextStep,
-  prevStep,
   setStep,
   setReviewHeader,
 }: ReviewFormProps): React.ReactElement => {
@@ -112,11 +110,7 @@ const ReviewForm = ({
             Edit
           </Button>
         </HStack>
-        <IndividualDetails
-          title="Individual details"
-          childrenDetails={[]}
-          caregiverDetails={[]}
-        />
+        <IndividualDetails childrenDetails={[]} caregiverDetails={[]} />
       </Stack>
 
       <Stack padding="32px" spacing="16px">

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -41,7 +41,6 @@ const Intake = (): React.ReactElement => {
   const [caregivers, setCaregivers] = useState<Caregivers>([]);
 
   const nextStep = () => setStep(step + 1);
-  const prevStep = () => setStep(step - 1);
 
   const renderDetailsForm = () => {
     switch (step) {
@@ -64,7 +63,14 @@ const Intake = (): React.ReactElement => {
           />
         );
       case IntakeSteps.INDIVIDUAL_DETAILS:
-        return <IndividualDetailsEntry nextStep={nextStep} setStep={setStep} />;
+        return (
+          <IndividualDetailsEntry
+            nextStep={nextStep}
+            setStep={setStep}
+            caregivers={caregivers}
+            setCaregivers={setCaregivers}
+          />
+        );
       case IntakeSteps.PROGRAM_DETAILS:
         return (
           <ProgramForm
@@ -86,7 +92,6 @@ const Intake = (): React.ReactElement => {
                 programDetails={programDetails}
                 setProgramDetails={setProgramDetails}
                 nextStep={nextStep}
-                prevStep={prevStep}
                 setStep={setStep}
                 setReviewHeader={setReviewHeader}
               />

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -9,9 +9,11 @@ import ProgramForm, { ProgramDetails } from "../intake/ProgramForm";
 import ReviewForm from "../intake/ReviewCaseForm";
 import IndividualDetailsEntry from "../intake/IndividualDetailsEntry";
 import { Caregivers } from "../intake/NewCaregiverModal";
+import IntakeSteps from "../intake/intakeSteps";
 
 const Intake = (): React.ReactElement => {
   const [step, setStep] = useState(0);
+  const [reviewHeader, setReviewHeader] = useState(false);
   const [referralDetails, setReferralDetails] = useState<ReferralDetails>({
     referringWorker: "",
     referringWorkerContact: "",
@@ -43,7 +45,7 @@ const Intake = (): React.ReactElement => {
 
   const renderDetailsForm = () => {
     switch (step) {
-      case 0:
+      case IntakeSteps.CASE_REFERRAL:
         return (
           <ReferralForm
             referralDetails={referralDetails}
@@ -52,7 +54,7 @@ const Intake = (): React.ReactElement => {
             setStep={setStep}
           />
         );
-      case 1:
+      case IntakeSteps.COURT_INFORMATION:
         return (
           <CourtInformationForm
             courtDetails={courtDetails}
@@ -61,16 +63,9 @@ const Intake = (): React.ReactElement => {
             setStep={setStep}
           />
         );
-      case 2:
-        return (
-          <IndividualDetailsEntry
-            nextStep={nextStep}
-            setStep={setStep}
-            caregivers={caregivers}
-            setCaregivers={setCaregivers}
-          />
-        );
-      case 3:
+      case IntakeSteps.INDIVIDUAL_DETAILS:
+        return <IndividualDetailsEntry nextStep={nextStep} setStep={setStep} />;
+      case IntakeSteps.PROGRAM_DETAILS:
         return (
           <ProgramForm
             programDetails={programDetails}
@@ -93,6 +88,7 @@ const Intake = (): React.ReactElement => {
                 nextStep={nextStep}
                 prevStep={prevStep}
                 setStep={setStep}
+                setReviewHeader={setReviewHeader}
               />
             </Box>
           </>
@@ -102,16 +98,25 @@ const Intake = (): React.ReactElement => {
 
   return (
     <>
-      {step === 4 ? (
+      {step === IntakeSteps.REVIEW_CASE_DETAILS ? (
         <IntakeHeader
           primaryTitle="Review Case Details"
           secondaryTitle="Initiate New Case"
         />
       ) : (
-        <IntakeHeader
-          primaryTitle="Initiate New Case"
-          secondaryTitle="Case Management"
-        />
+        <>
+          {reviewHeader ? (
+            <IntakeHeader
+              primaryTitle="Edit Case Intake Submission"
+              secondaryTitle="Case Management"
+            />
+          ) : (
+            <IntakeHeader
+              primaryTitle="Initiate New Case"
+              secondaryTitle="Case Management"
+            />
+          )}
+        </>
       )}
 
       <Box textAlign="center" padding="30px 0 40px 0">


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement ‘Edit’ button function in Review Case page](https://www.notion.so/uwblueprintexecs/Implement-Edit-button-function-in-Review-Case-page-c0ccf94f1b8644448b168f33f0b038fb)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added functionality to 'Edit' buttons on Review Case page
* Allows user to go to back to specific sections to modify entries
* Removed 'Previous' button from Review Case page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to localhost:3000/intake
2. Fill in fields if you want and go to Review Case page
3. Click on 'Edit' buttons to make sure they return to the correct pages
4. Make sure the intake header changes depending on page (Initiate New Case vs Edit Case Intake Submission)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure 'Edit' buttons direct to correct pages
* Make sure header changes accordingly
* Check that 'Previous' button has been removed


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
