### PR TITLE
Create Add ‘Other Permitted Individuals’ Modal

### DIFF
--- a/frontend/src/components/intake/PermittedIndividualsModal.tsx
+++ b/frontend/src/components/intake/PermittedIndividualsModal.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { Box, FormLabel, Icon, SimpleGrid } from "@chakra-ui/react";
+import { Phone, User } from "react-feather";
+import ModalComponent from "../common/ModalComponent";
+import CustomInput from "../common/CustomInput";
+import OptionalLabel from "./OptionalLabel";
+
+type PermittedIndividualsProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const PermittedIndividualsModal = ({
+  isOpen,
+  onClose,
+}: PermittedIndividualsProps): React.ReactElement => {
+  const [providerName, setProviderName] = useState("");
+  const [relationshipToChild, setRelationshipToChild] = useState("");
+  return (
+    <Box>
+      <ModalComponent
+        primaryTitle="Other Permitted Individuals"
+        secondaryTitle="Individual Details"
+        modalContent={
+          <Box>
+            <SimpleGrid columns={2} spacingX="3rem" spacingY="0.75rem">
+              <Box>
+                <FormLabel htmlFor="providerName">NAME</FormLabel>
+                <CustomInput
+                  id="providerName"
+                  name="providerName"
+                  type="string"
+                  placeholder="Enter full name of individual"
+                  icon={<Icon as={User} />}
+                  onChange={(event) => {
+                    setProviderName(event.target.value);
+                  }}
+                />
+              </Box>
+              <Box>
+                <FormLabel htmlFor="phoneNo">
+                  PERMITTED INDIVIDUAL PHONE <OptionalLabel />
+                </FormLabel>
+                <CustomInput
+                  id="phoneNo"
+                  name="phoneNo"
+                  type="string"
+                  placeholder="e.g. 555-555-5555"
+                  icon={<Icon as={Phone} />}
+                />
+              </Box>
+            </SimpleGrid>
+            <Box paddingTop="10px">
+              <FormLabel htmlFor="relationshipToChild">
+                RELATIONSHIP TO CHILD(REN)
+              </FormLabel>
+              <CustomInput
+                id="relationshipToChild"
+                name="relationshipToChild"
+                type="string"
+                placeholder="Note permitted individual's relationship to child(ren)..."
+                onChange={(event) => {
+                  setRelationshipToChild(event.target.value);
+                }}
+              />
+            </Box>
+            <Box paddingTop="10px">
+              <FormLabel htmlFor="additionalNotes">
+                ADDITIONAL NOTES <OptionalLabel />
+              </FormLabel>
+              <CustomInput
+                id="additionalNotes"
+                name="additionalNotes"
+                type="string"
+                placeholder="Click to add notes..."
+                height="10rem"
+                paddingBottom="7rem"
+              />
+            </Box>
+          </Box>
+        }
+        onClick={() => {}} // empty for now
+        isOpen={isOpen}
+        onClose={() => {
+          setProviderName("");
+          setRelationshipToChild("");
+          onClose();
+        }}
+        disabled={!(providerName && relationshipToChild)}
+        primaryButtonTitle="Save permitted individual"
+      />
+    </Box>
+  );
+};
+
+export default PermittedIndividualsModal;

--- a/frontend/src/components/intake/ProgramForm.tsx
+++ b/frontend/src/components/intake/ProgramForm.tsx
@@ -7,6 +7,7 @@ import {
   SimpleGrid,
   Box,
   FormLabel,
+  useDisclosure,
 } from "@chakra-ui/react";
 import {
   Truck,
@@ -24,6 +25,7 @@ import { CustomSelectField } from "./CustomSelectField";
 import Stepper from "./Stepper";
 import IntakeSteps from "./intakeSteps";
 import IntakeFooter from "./IntakeFormFooter";
+import PermittedIndividualsModal from "./PermittedIndividualsModal";
 
 export type ProgramDetails = {
   transportationRequirements: string;
@@ -69,6 +71,12 @@ const ProgramForm = ({
     nextStep();
     setProgramDetails(formik.values);
   };
+
+  const {
+    onOpen: onOpenAddPermittedIndividuals,
+    isOpen: isOpenAddPermittedIndividuals,
+    onClose: onCloseAddPermittedIndividuals,
+  } = useDisclosure();
 
   return (
     <>
@@ -192,15 +200,22 @@ const ProgramForm = ({
             <Text alignSelf="start" textStyle="title-medium">
               Other permitted individuals
             </Text>
-            <Button
-              alignSelf="end"
-              leftIcon={<Icon as={UserPlus} />}
-              variant="secondary"
-              mr={2}
-            >
-              Add
-            </Button>
+            {!readOnly && (
+              <Button
+                alignSelf="end"
+                leftIcon={<Icon as={UserPlus} />}
+                variant="secondary"
+                mr={2}
+                onClick={onOpenAddPermittedIndividuals}
+              >
+                Add
+              </Button>
+            )}
           </Box>
+          <PermittedIndividualsModal
+            isOpen={isOpenAddPermittedIndividuals}
+            onClose={onCloseAddPermittedIndividuals}
+          />
         </Form>
       </FormikProvider>
       {!hideFooter && (


### PR DESCRIPTION
## Notion ticket link
[Create Add ‘Other Permitted Individuals’ Modal](https://www.notion.so/uwblueprintexecs/Create-Add-Other-Permitted-Individuals-Modal-f7cbdc2f13d64a2289a62b91c814729e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added UI for 'Other Permitted Individuals' modal under 'Program Details' page in intake
* No actual functionality, all it does is show the modal
* Modal does not appear on the 'Review Case Details' page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to /intake
2. Go to 'Program Details' tab in the stepper
3. At the bottom click the 'Add' button, modal should appear


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure design is correct and buttons work


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
