### PR TITLE
Implement “Download Attachment” button

### DIFF
--- a/frontend/src/components/intake/CourtInformationForm.tsx
+++ b/frontend/src/components/intake/CourtInformationForm.tsx
@@ -75,18 +75,19 @@ const CourtInformationForm = ({
   };
 
   const downloadFile = () => {
-    if(!formik.values.orderReferral || !formik.values.orderReferral.name){
-      return
+    if (!formik.values.orderReferral || !formik.values.orderReferral.name) {
+      return;
     }
 
-    const blob = new Blob([formik.values.orderReferral], { type: 'application/pdf' });
+    const blob = new Blob([formik.values.orderReferral], {
+      type: "application/pdf",
+    });
     const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.download = formik.values.orderReferral.name;
     link.href = url;
     link.click();
     URL.revokeObjectURL(url);
-
   };
 
   return (
@@ -160,9 +161,9 @@ const CourtInformationForm = ({
               />
               {readOnly ? (
                 <Button
-                    variant="tertiary"
-                    leftIcon={<Icon as={Download} />}
-                    onClick={downloadFile}
+                  variant="tertiary"
+                  leftIcon={<Icon as={Download} />}
+                  onClick={downloadFile}
                 >
                   Download attachment {/* TODO: implement download button */}
                 </Button>

--- a/frontend/src/components/intake/CourtInformationForm.tsx
+++ b/frontend/src/components/intake/CourtInformationForm.tsx
@@ -73,6 +73,22 @@ const CourtInformationForm = ({
     nextStep();
     setCourtDetails(formik.values);
   };
+
+  const downloadFile = () => {
+    if(!formik.values.orderReferral || !formik.values.orderReferral.name){
+      return
+    }
+
+    const blob = new Blob([formik.values.orderReferral], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = formik.values.orderReferral.name;
+    link.href = url;
+    link.click();
+    URL.revokeObjectURL(url);
+
+  };
+
   return (
     <>
       {!hideStepper && (
@@ -143,7 +159,11 @@ const CourtInformationForm = ({
                 style={{ cursor: "pointer" }}
               />
               {readOnly ? (
-                <Button variant="tertiary" leftIcon={<Icon as={Download} />}>
+                <Button
+                    variant="tertiary"
+                    leftIcon={<Icon as={Download} />}
+                    onClick={downloadFile}
+                >
                   Download attachment {/* TODO: implement download button */}
                 </Button>
               ) : (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement “Download Attachment” button](https://www.notion.so/uwblueprintexecs/Implement-Download-Attachment-button-99d2ba30742c421b888c61a401ef4ad1?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented a button that downloads the orderreferral file object stored on upload 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.http://localhost:3000/intake


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* ensuring that the button is bug-free


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
