### PR TITLE
add return to dashboard & back to submission review functionality

### DIFF
--- a/frontend/src/components/common/ModalComponent.tsx
+++ b/frontend/src/components/common/ModalComponent.tsx
@@ -1,13 +1,14 @@
 import {
   Button,
   Modal,
-  ModalOverlay,
-  ModalContent,
-  Text,
-  ModalHeader,
-  ModalFooter,
-  ModalCloseButton,
   ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spacer,
+  Text,
 } from "@chakra-ui/react";
 import React from "react";
 
@@ -20,6 +21,7 @@ export type ModalProps = {
   onClick: () => void;
   isOpen: boolean;
   onClose: () => void;
+  unsavedProgressModal?: boolean;
 };
 
 const ModalComponent = ({
@@ -31,6 +33,7 @@ const ModalComponent = ({
   secondaryTitle,
   isOpen,
   onClose,
+  unsavedProgressModal,
 }: ModalProps): React.ReactElement => (
   <Modal
     isCentered
@@ -50,10 +53,16 @@ const ModalComponent = ({
       </ModalHeader>
       <ModalBody>
         {modalContent}
-        <ModalFooter paddingTop="56px" paddingRight="0px" paddingBottom="0px">
+        <ModalFooter
+          paddingTop="56px"
+          paddingBottom="0px"
+          paddingLeft="0px"
+          paddingRight="0px"
+        >
           <Button variant="tertiary" onClick={onClose}>
             Cancel
           </Button>
+          {unsavedProgressModal && <Spacer />}
           <Button variant="primary" disabled={disabled} onClick={onClick}>
             {primaryButtonTitle}
           </Button>

--- a/frontend/src/components/intake/UnsavedProgressModal.tsx
+++ b/frontend/src/components/intake/UnsavedProgressModal.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+import ModalComponent from "../common/ModalComponent";
+
+type UnsavedProgressProps = {
+  isOpen: boolean;
+  onClick: () => void;
+  onClose: () => void;
+  reviewVersion?: boolean;
+};
+
+const UnsavedProgressModal = ({
+  isOpen,
+  onClick,
+  onClose,
+  reviewVersion,
+}: UnsavedProgressProps): React.ReactElement => {
+  return (
+    <Box>
+      <ModalComponent
+        primaryTitle="Unsaved Progress"
+        secondaryTitle="Case Referral"
+        modalContent={
+          <Text>
+            Are you sure you want to leave this page? Your{" "}
+            {reviewVersion ? "new edits" : "information"} will not be saved if
+            you go back.
+          </Text>
+        }
+        onClick={() => {
+          onClick();
+          onClose();
+        }}
+        isOpen={isOpen}
+        onClose={() => {
+          onClose();
+        }}
+        disabled={false}
+        primaryButtonTitle="Continue"
+        unsavedProgressModal
+      />
+    </Box>
+  );
+};
+
+export default UnsavedProgressModal;

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -1,6 +1,6 @@
-import { Box, Button, Icon, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Text, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
-import { ChevronLeft } from "react-feather";
+import { ArrowLeft } from "react-feather";
 import { useHistory } from "react-router-dom";
 import IntakeHeader from "../IntakeHeader";
 import { Providers } from "../NewProviderModal";
@@ -82,13 +82,12 @@ const AddChild = (): React.ReactElement => {
         borderColor="gray.100"
       >
         <Button
-          color="blue.400"
-          variant="link"
+          leftIcon={<ArrowLeft />}
           onClick={() => {
-            history.goBack();
             // TODO: Fix route to navigate back to individual details entry intake page
+            history.goBack();
           }}
-          leftIcon={<Icon as={ChevronLeft} h="16px" />}
+          variant="tertiary"
         >
           Back to case individuals
         </Button>

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
-import { Box, Container } from "@chakra-ui/react";
+import { Box, Button, Container, useDisclosure } from "@chakra-ui/react";
+import { ArrowLeft } from "react-feather";
+import { useHistory } from "react-router-dom";
 import CourtInformationForm, {
   CourtDetails,
 } from "../intake/CourtInformationForm";
@@ -12,8 +14,17 @@ import { Caregivers } from "../intake/NewCaregiverModal";
 import IntakeSteps from "../intake/intakeSteps";
 import { PermittedIndividuals } from "../intake/PermittedIndividualsModal";
 import PermittedIndividualsForm from "../intake/PermittedIndividualsForm";
+import UnsavedProgressModal from "../intake/UnsavedProgressModal";
 
 const Intake = (): React.ReactElement => {
+  // TODO: remove useHistory once dashboard is implemented
+  const history = useHistory();
+  const {
+    onOpen: onOpenUnsavedProgress,
+    isOpen: isOpenUnsavedProgress,
+    onClose: onCloseUnsavedProgress,
+  } = useDisclosure();
+
   const [step, setStep] = useState(0);
   const [reviewHeader, setReviewHeader] = useState(false);
   const [referralDetails, setReferralDetails] = useState<ReferralDetails>({
@@ -133,11 +144,42 @@ const Intake = (): React.ReactElement => {
           )}
         </>
       )}
-      <Box textAlign="center" padding="30px 0 40px 0">
+      <Box padding="30px 0 40px 0">
         <Container maxWidth="container.xl" padding="30px 96px">
+          {step !== IntakeSteps.REVIEW_CASE_DETAILS && (
+            <Button
+              leftIcon={<ArrowLeft />}
+              marginBottom="30px"
+              onClick={() => {
+                onOpenUnsavedProgress();
+              }}
+              variant="tertiary"
+            >
+              {reviewHeader ? "Back to Submission Review" : "Back to Dashboard"}
+            </Button>
+          )}
           {renderDetailsForm()}
         </Container>
       </Box>
+      {reviewHeader ? (
+        <UnsavedProgressModal
+          isOpen={isOpenUnsavedProgress}
+          onClick={() => {
+            setStep(IntakeSteps.REVIEW_CASE_DETAILS);
+          }}
+          onClose={onCloseUnsavedProgress}
+          reviewVersion={reviewHeader}
+        />
+      ) : (
+        <UnsavedProgressModal
+          isOpen={isOpenUnsavedProgress}
+          onClick={() => {
+            // TODO: remove this once dashboard is implemented
+            history.goBack();
+          }}
+          onClose={onCloseUnsavedProgress}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add return to dashboard & back to submission review functionality](https://www.notion.so/uwblueprintexecs/Add-return-to-dashboard-back-to-submission-review-functionality-df0828806f954a98be02a7534930cf6d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 'Back to dashboard / submission review' buttons and confirmation modals
<img width="1130" alt="Screen Shot 2023-03-21 at 2 52 11 PM" src="https://user-images.githubusercontent.com/66758256/226712041-d5184782-4b49-4fed-bc61-16e8efc464d1.png">
<img width="1125" alt="Screen Shot 2023-03-21 at 2 52 00 PM" src="https://user-images.githubusercontent.com/66758256/226712116-8c046753-8d32-4654-94c4-3f3378990bfe.png">


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/intake` and click the buttons on the initial intake page and also in edit submission mode


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure the UI is correct and that the modal is correct in both versions


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
