### PR TITLE
Implement “Back to case individuals” button from Add Child

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,6 @@ import Intake from "./components/pages/IntakePage";
 import Visit from "./components/pages/VisitPage";
 import Home from "./components/pages/HomePage";
 import NotFound from "./components/pages/NotFound";
-import AddChild from "./components/intake/child-information/AddChildPage";
 import Default from "./components/pages/Default";
 
 // import PrivateRoute from "./components/auth/PrivateRoute";
@@ -67,11 +66,6 @@ const App = (): React.ReactElement => {
                 <Route exact path={Routes.INTAKE_PAGE} component={Intake} />
                 <Route exact path={Routes.VISIT_PAGE} component={Visit} />
                 <Route exact path={Routes.DEFAULT_PAGE} component={Default} />
-                <Route
-                  exact
-                  path={Routes.ADD_CHILD_PAGE}
-                  component={AddChild}
-                />
                 <Route exact path="*" component={NotFound} />
               </Switch>
             </Router>

--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { VStack, Icon } from "@chakra-ui/react";
 import { UserPlus } from "react-feather";
-import { useHistory } from "react-router-dom";
 import PromptBox from "./PromptBox";
-import { ADD_CHILD_PAGE } from "../../constants/Routes";
 import { Caregivers } from "./NewCaregiverModal";
 import Stepper from "./Stepper";
 import IntakeSteps from "./intakeSteps";
@@ -27,8 +25,6 @@ const IndividualDetailsEntry = ({
   caregivers,
   setCaregivers,
 }: IndividualDetailsEntryProp): React.ReactElement => {
-  const history = useHistory();
-
   const onNextStep = () => {
     nextStep();
     // TODO: SET UP SAVING INVIDUAL DETAILS
@@ -57,7 +53,7 @@ const IndividualDetailsEntry = ({
             buttonText="Add child"
             buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
             onButtonClick={() => {
-              history.push(ADD_CHILD_PAGE);
+              setStep(IntakeSteps.ADD_CHILD);
             }}
           />
           <CaregiverForm

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -1,17 +1,26 @@
 import { Box, Button, Text, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { ArrowLeft } from "react-feather";
-import { useHistory } from "react-router-dom";
 import IntakeHeader from "../IntakeHeader";
+import IntakeSteps from "../intakeSteps";
 import { Providers } from "../NewProviderModal";
 import ChildInformationForm, { ChildDetails } from "./ChildInformationForm";
 import ChildProviderForm from "./ChildProviderForm";
 import FormSelector from "./FormSelector";
 import SchoolDaycareForm, { SchoolDetails } from "./SchoolDaycareForm";
 
-const AddChild = (): React.ReactElement => {
+enum AddChildSteps {
+  CHILD_INFORMATION_FORM,
+  SCHOOL_DAYCARE_FORM,
+  CHILD_PROVIDER_FORM,
+}
+
+type AddChildProps = {
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const AddChild = ({ setStep }: AddChildProps): React.ReactElement => {
   const [activeFormIndex, setActiveFormIndex] = useState(0);
-  const history = useHistory();
 
   const [childDetails, setChildDetails] = useState<ChildDetails>({
     childName: "",
@@ -42,21 +51,21 @@ const AddChild = (): React.ReactElement => {
 
   const renderChildForm = () => {
     switch (activeFormIndex) {
-      case 0:
+      case AddChildSteps.CHILD_INFORMATION_FORM:
         return (
           <ChildInformationForm
             childDetails={childDetails}
             setChildDetails={setChildDetails}
           />
         );
-      case 1:
+      case AddChildSteps.SCHOOL_DAYCARE_FORM:
         return (
           <SchoolDaycareForm
             schoolDetails={schoolDetails}
             setSchoolDetails={setSchoolDetails}
           />
         );
-      case 2:
+      case AddChildSteps.CHILD_PROVIDER_FORM:
         return (
           <ChildProviderForm
             providers={providers}
@@ -84,8 +93,7 @@ const AddChild = (): React.ReactElement => {
         <Button
           leftIcon={<ArrowLeft />}
           onClick={() => {
-            // TODO: Fix route to navigate back to individual details entry intake page
-            history.goBack();
+            setStep(IntakeSteps.INDIVIDUAL_DETAILS);
           }}
           variant="tertiary"
         >

--- a/frontend/src/components/intake/intakeSteps.ts
+++ b/frontend/src/components/intake/intakeSteps.ts
@@ -4,6 +4,7 @@ enum IntakeSteps {
   INDIVIDUAL_DETAILS,
   PROGRAM_DETAILS,
   REVIEW_CASE_DETAILS,
+  ADD_CHILD,
 }
 
 export default IntakeSteps;

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -135,19 +135,12 @@ const Intake = (): React.ReactElement => {
         );
       default:
         return (
-          <>
-            {reviewHeader ? (
-              <IntakeHeader
-                primaryTitle="Edit Case Intake Submission"
-                secondaryTitle="Case Management"
-              />
-            ) : (
-              <IntakeHeader
-                primaryTitle="Initiate New Case"
-                secondaryTitle="Case Management"
-              />
-            )}
-          </>
+          <IntakeHeader
+            primaryTitle={
+              reviewHeader ? "Edit Case Intake Submission" : "Initiate New Case"
+            }
+            secondaryTitle="Case Management"
+          />
         );
     }
   };
@@ -178,25 +171,19 @@ const Intake = (): React.ReactElement => {
               {renderDetailsForm()}
             </Container>
           </Box>
-          {reviewHeader ? (
-            <UnsavedProgressModal
-              isOpen={isOpenUnsavedProgress}
-              onClick={() => {
+          <UnsavedProgressModal
+            isOpen={isOpenUnsavedProgress}
+            onClick={() => {
+              if (reviewHeader) {
                 setStep(IntakeSteps.REVIEW_CASE_DETAILS);
-              }}
-              onClose={onCloseUnsavedProgress}
-              reviewVersion={reviewHeader}
-            />
-          ) : (
-            <UnsavedProgressModal
-              isOpen={isOpenUnsavedProgress}
-              onClick={() => {
+              } else {
                 // TODO: remove this once dashboard is implemented
                 history.goBack();
-              }}
-              onClose={onCloseUnsavedProgress}
-            />
-          )}
+              }
+            }}
+            onClose={onCloseUnsavedProgress}
+            reviewVersion={reviewHeader}
+          />
         </>
       )}
     </>

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -15,6 +15,7 @@ import IntakeSteps from "../intake/intakeSteps";
 import { PermittedIndividuals } from "../intake/PermittedIndividualsModal";
 import PermittedIndividualsForm from "../intake/PermittedIndividualsForm";
 import UnsavedProgressModal from "../intake/UnsavedProgressModal";
+import AddChild from "../intake/child-information/AddChildPage";
 
 const Intake = (): React.ReactElement => {
   // TODO: remove useHistory once dashboard is implemented
@@ -104,6 +105,7 @@ const Intake = (): React.ReactElement => {
           </>
         );
       default:
+        // IntakeSteps.REVIEW_CASE_DETAILS
         return (
           <Box style={{ textAlign: "center", padding: "30px 0px 40px 0px" }}>
             <ReviewForm
@@ -122,67 +124,80 @@ const Intake = (): React.ReactElement => {
     }
   };
 
+  const renderIntakeHeader = () => {
+    switch (step) {
+      case IntakeSteps.REVIEW_CASE_DETAILS:
+        return (
+          <IntakeHeader
+            primaryTitle="Review Case Details"
+            secondaryTitle="Initiate New Case"
+          />
+        );
+      default:
+        return (
+          <>
+            {reviewHeader ? (
+              <IntakeHeader
+                primaryTitle="Edit Case Intake Submission"
+                secondaryTitle="Case Management"
+              />
+            ) : (
+              <IntakeHeader
+                primaryTitle="Initiate New Case"
+                secondaryTitle="Case Management"
+              />
+            )}
+          </>
+        );
+    }
+  };
+
   return (
     <>
-      {step === IntakeSteps.REVIEW_CASE_DETAILS ? (
-        <IntakeHeader
-          primaryTitle="Review Case Details"
-          secondaryTitle="Initiate New Case"
-        />
+      {step === IntakeSteps.ADD_CHILD ? (
+        <AddChild setStep={setStep} />
       ) : (
         <>
+          {renderIntakeHeader()}
+          <Box padding="30px 0 40px 0">
+            <Container maxWidth="container.xl" padding="30px 96px">
+              {step !== IntakeSteps.REVIEW_CASE_DETAILS && (
+                <Button
+                  leftIcon={<ArrowLeft />}
+                  marginBottom="30px"
+                  onClick={() => {
+                    onOpenUnsavedProgress();
+                  }}
+                  variant="tertiary"
+                >
+                  {reviewHeader
+                    ? "Back to Submission Review"
+                    : "Back to Dashboard"}
+                </Button>
+              )}
+              {renderDetailsForm()}
+            </Container>
+          </Box>
           {reviewHeader ? (
-            <IntakeHeader
-              primaryTitle="Edit Case Intake Submission"
-              secondaryTitle="Case Management"
+            <UnsavedProgressModal
+              isOpen={isOpenUnsavedProgress}
+              onClick={() => {
+                setStep(IntakeSteps.REVIEW_CASE_DETAILS);
+              }}
+              onClose={onCloseUnsavedProgress}
+              reviewVersion={reviewHeader}
             />
           ) : (
-            <IntakeHeader
-              primaryTitle="Initiate New Case"
-              secondaryTitle="Case Management"
+            <UnsavedProgressModal
+              isOpen={isOpenUnsavedProgress}
+              onClick={() => {
+                // TODO: remove this once dashboard is implemented
+                history.goBack();
+              }}
+              onClose={onCloseUnsavedProgress}
             />
           )}
         </>
-      )}
-      <Box padding="30px 0 40px 0">
-        <Container
-          maxWidth="container.xl"
-          padding="30px 96px"
-          marginBottom="100px"
-        >
-          {step !== IntakeSteps.REVIEW_CASE_DETAILS && (
-            <Button
-              leftIcon={<ArrowLeft />}
-              marginBottom="30px"
-              onClick={() => {
-                onOpenUnsavedProgress();
-              }}
-              variant="tertiary"
-            >
-              {reviewHeader ? "Back to Submission Review" : "Back to Dashboard"}
-            </Button>
-          )}
-          {renderDetailsForm()}
-        </Container>
-      </Box>
-      {reviewHeader ? (
-        <UnsavedProgressModal
-          isOpen={isOpenUnsavedProgress}
-          onClick={() => {
-            setStep(IntakeSteps.REVIEW_CASE_DETAILS);
-          }}
-          onClose={onCloseUnsavedProgress}
-          reviewVersion={reviewHeader}
-        />
-      ) : (
-        <UnsavedProgressModal
-          isOpen={isOpenUnsavedProgress}
-          onClick={() => {
-            // TODO: remove this once dashboard is implemented
-            history.goBack();
-          }}
-          onClose={onCloseUnsavedProgress}
-        />
       )}
     </>
   );

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -1,6 +1,5 @@
 export const HOME_PAGE = "/";
 export const INTAKE_PAGE = "/intake";
-export const ADD_CHILD_PAGE = "/intake/add-child";
 export const VISIT_PAGE = "/visit";
 export const LOGIN_PAGE = "/login";
 export const SIGNUP_PAGE = "/signup";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement “Back to case individuals” button from Add Child](https://www.notion.so/uwblueprintexecs/Implement-Back-to-case-individuals-button-from-Add-Child-12e06f96d38147038aa36ccb2be64171)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed `/intake/add-child` route and moved add child flow to the intake page


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Type stuff into intake form
2. Go to 'Individual details' page and click 'Add child'
3. Click 'Back to case individuals' and make sure it redirects to'Individual details' page
4. Make sure the stuff you entered into the form earlier is still there


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Check that flow is correct


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
