### PR TITLE
Fix footer for smaller sized screens + Add database wipe script

### DIFF
--- a/backend/python/tools/db_wipe.py
+++ b/backend/python/tools/db_wipe.py
@@ -1,0 +1,19 @@
+from app import create_app
+from app.models import db
+
+
+"""
+Wipe postgres db as well as any associated auth entried within firebase auth store
+"""
+
+app = create_app("development")
+
+from app.rest.user_routes import user_service # we have to import this after create_app since application context hasn't been pushed onto stack yet
+for userDTO in user_service.get_users():
+    user_service.delete_user_by_id(userDTO.id)
+
+# drop tables (Note, the db schema has been provided to db when create_app is called)
+db.drop_all()
+
+# recreate tables
+db.create_all()

--- a/backend/python/tools/db_wipe.py
+++ b/backend/python/tools/db_wipe.py
@@ -1,14 +1,16 @@
 from app import create_app
 from app.models import db
 
-
 """
 Wipe postgres db as well as any associated auth entried within firebase auth store
 """
 
 app = create_app("development")
 
-from app.rest.user_routes import user_service # we have to import this after create_app since application context hasn't been pushed onto stack yet
+from app.rest.user_routes import (  # we have to import this after create_app since application context hasn't been pushed onto stack yet
+    user_service,
+)
+
 for userDTO in user_service.get_users():
     user_service.delete_user_by_id(userDTO.id)
 

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -188,7 +188,7 @@ const Intake = (): React.ReactElement => {
       ) : (
         <>
           {renderIntakeHeader()}
-          <Box padding="30px 0 200px 0">
+          <Box padding="30px 0 160px 0">
             <Container maxWidth="container.xl" padding="30px 96px">
               {step !== IntakeSteps.REVIEW_CASE_DETAILS &&
                 step !== IntakeSteps.FORM_COMPLETE && (

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -188,7 +188,7 @@ const Intake = (): React.ReactElement => {
       ) : (
         <>
           {renderIntakeHeader()}
-          <Box padding="30px 0 150px 0">
+          <Box padding="30px 0 200px 0">
             <Container maxWidth="container.xl" padding="30px 96px">
               {step !== IntakeSteps.REVIEW_CASE_DETAILS &&
                 step !== IntakeSteps.FORM_COMPLETE && (

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -188,7 +188,7 @@ const Intake = (): React.ReactElement => {
       ) : (
         <>
           {renderIntakeHeader()}
-          <Box padding="30px 0 40px 0">
+          <Box padding="30px 0 150px 0">
             <Container maxWidth="container.xl" padding="30px 96px">
               {step !== IntakeSteps.REVIEW_CASE_DETAILS &&
                 step !== IntakeSteps.FORM_COMPLETE && (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fix footer for smaller sized screens](https://www.notion.so/uwblueprintexecs/Fix-footer-for-smaller-sized-screens-4b7f3c7330df41ba9a7cf07051638457)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Increase margin bottom on intake footer component


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go to http://localhost:3000/intake to check out the new margin


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* This is not a robust fix. If the footer height increases, then we might need to readjust the intake page bottom margins again.  (i.e. tight coupling between footer and intake page) A better solution would be to provide a ref of the wrapper html element to the footer component. The footer component's height would then we added on-top of the wrapper height. However, implementation details might get complex and I think a simple solution suffices for now (Since we don't worry too much about dynamic resizing).


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
