### PR TITLE
Individual details section “view and edit details” button for children

### DIFF
--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -1,18 +1,20 @@
 import React from "react";
-import { VStack, Icon } from "@chakra-ui/react";
-import { UserPlus } from "react-feather";
-import PromptBox from "./PromptBox";
+import { VStack } from "@chakra-ui/react";
 import { Caregivers } from "./NewCaregiverModal";
 import Stepper from "./Stepper";
 import IntakeSteps from "./intakeSteps";
 import IntakeFooter from "./IntakeFormFooter";
+import ChildrenForm from "./indivDetails/ChildrenForm";
 import CaregiverForm from "./indivDetails/CaregiverProviderForm";
+import { Children } from "./child-information/AddChildPage";
 
 export type IndividualDetailsEntryProp = {
   nextStep: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   hideStepper?: boolean;
   hideFooter?: boolean;
+  childrens: Children;
+  setChildren: React.Dispatch<React.SetStateAction<Children>>;
   caregivers: Caregivers;
   setCaregivers: React.Dispatch<React.SetStateAction<Caregivers>>;
 };
@@ -22,6 +24,8 @@ const IndividualDetailsEntry = ({
   setStep,
   hideStepper,
   hideFooter,
+  childrens,
+  setChildren,
   caregivers,
   setCaregivers,
 }: IndividualDetailsEntryProp): React.ReactElement => {
@@ -47,14 +51,10 @@ const IndividualDetailsEntry = ({
       )}
       <React.Fragment key="IndividualDetailsEntry">
         <VStack padding="32px" spacing="24px">
-          <PromptBox
-            headerText="Children"
-            descriptionText="No children have been added to the case yet. "
-            buttonText="Add child"
-            buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
-            onButtonClick={() => {
-              setStep(IntakeSteps.ADD_CHILD);
-            }}
+          <ChildrenForm
+            childrens={childrens}
+            setChildren={setChildren}
+            setStep={setStep}
           />
           <CaregiverForm
             caregivers={caregivers}

--- a/frontend/src/components/intake/IndividualDetailsEntry.tsx
+++ b/frontend/src/components/intake/IndividualDetailsEntry.tsx
@@ -17,6 +17,8 @@ export type IndividualDetailsEntryProp = {
   setChildren: React.Dispatch<React.SetStateAction<Children>>;
   caregivers: Caregivers;
   setCaregivers: React.Dispatch<React.SetStateAction<Caregivers>>;
+  selectedIndexChild: number;
+  setSelectedIndexChild: React.Dispatch<React.SetStateAction<number>>;
 };
 
 const IndividualDetailsEntry = ({
@@ -28,6 +30,7 @@ const IndividualDetailsEntry = ({
   setChildren,
   caregivers,
   setCaregivers,
+  setSelectedIndexChild,
 }: IndividualDetailsEntryProp): React.ReactElement => {
   const onNextStep = () => {
     nextStep();
@@ -55,6 +58,7 @@ const IndividualDetailsEntry = ({
             childrens={childrens}
             setChildren={setChildren}
             setStep={setStep}
+            setSelectedIndexChild={setSelectedIndexChild}
           />
           <CaregiverForm
             caregivers={caregivers}

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Text, VStack } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowLeft } from "react-feather";
 import IntakeHeader from "../IntakeHeader";
 import IntakeSteps from "../intakeSteps";
@@ -80,6 +80,14 @@ const AddChild = ({
     setChildren([...childrens]);
     setStep(IntakeSteps.INDIVIDUAL_DETAILS);
   };
+
+  useEffect(() => {
+    if (selectedIndexChild >= 0) {
+      setChildDetails(childrens[selectedIndexChild].childDetails);
+      setSchoolDetails(childrens[selectedIndexChild].schoolDetails);
+      setProviders(childrens[selectedIndexChild].providers);
+    }
+  }, [childrens, selectedIndexChild]);
 
   const renderChildForm = () => {
     switch (activeFormIndex) {

--- a/frontend/src/components/intake/child-information/AddChildPage.tsx
+++ b/frontend/src/components/intake/child-information/AddChildPage.tsx
@@ -21,9 +21,10 @@ type AddChildProps = {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   childrens: Children;
   setChildren: React.Dispatch<React.SetStateAction<Children>>;
+  selectedIndexChild: number;
 };
 
-type ChildrenDetails = {
+export type ChildrenDetails = {
   childDetails: ChildDetails;
   schoolDetails: SchoolDetails;
   providers: Providers;
@@ -36,6 +37,7 @@ const AddChild = ({
   setStep,
   childrens,
   setChildren,
+  selectedIndexChild,
 }: AddChildProps): React.ReactElement => {
   const [activeFormIndex, setActiveFormIndex] = useState(0);
 
@@ -63,15 +65,19 @@ const AddChild = ({
   // TODO: Check other required fields
 
   const childFormSubmitHandler = () => {
-    // TODO: Do something with the information
-    setChildren((prevChildren) => [
-      ...prevChildren,
-      {
-        childDetails: { ...childDetails },
-        schoolDetails: { ...schoolDetails },
-        providers: [...providers],
-      },
-    ]);
+    const updatedChild = {
+      childDetails: { ...childDetails },
+      schoolDetails: { ...schoolDetails },
+      providers: [...providers],
+    };
+
+    if (selectedIndexChild >= 0) {
+      childrens.splice(selectedIndexChild, 1, updatedChild);
+    } else {
+      childrens.push(updatedChild);
+    }
+
+    setChildren([...childrens]);
     setStep(IntakeSteps.INDIVIDUAL_DETAILS);
   };
 
@@ -104,10 +110,6 @@ const AddChild = ({
         return <Text>Error</Text>;
     }
   };
-
-  // REMOVE THIS ONCE YOU CALL CHILDRENS
-  // eslint-disable-next-line no-console
-  console.log(childrens);
 
   return (
     <>

--- a/frontend/src/components/intake/child-information/ChildInformationForm.tsx
+++ b/frontend/src/components/intake/child-information/ChildInformationForm.tsx
@@ -34,121 +34,127 @@ const ChildInformationForm = ({
   };
 
   return (
-    <Formik initialValues={childDetails} onSubmit={onSubmit}>
-      <Form style={{ padding: "2rem 12rem" }}>
-        <FormControl style={{ padding: "30px" }}>
-          <SimpleGrid columns={2} spacingX="3rem" spacingY="0.75rem">
-            <Box>
-              <FormLabel htmlFor="childName">NAME</FormLabel>
-              <Field
-                as={CustomInput}
-                id="childName"
-                name="childName"
-                type="string"
-                placeholder="Enter name of child"
-                icon={<Icon as={User} />}
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setChildDetails({
-                    ...childDetails,
-                    childName: e.target.value,
-                  })
-                }
-              />
-            </Box>
-            <Box>
-              <FormLabel htmlFor="dateOfBirth">DATE OF BIRTH</FormLabel>
-              <Field
-                as={CustomInput}
-                name="dateOfBirth"
-                id="dateOfBirth"
-                type="string"
-                placeholder="YYYY-MM-DD"
-                icon={<Icon as={Calendar} />}
-                onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setChildDetails({
-                    ...childDetails,
-                    dateOfBirth: e.target.value,
-                  })
-                }
-              />
-            </Box>
-            <Box>
-              <FormLabel htmlFor="cpinFileNumber">
-                CHILD FILE CPIN NUMBER
+    <>
+      <Formik
+        enableReinitialize
+        initialValues={childDetails}
+        onSubmit={onSubmit}
+      >
+        <Form style={{ padding: "2rem 12rem" }}>
+          <FormControl style={{ padding: "30px" }}>
+            <SimpleGrid columns={2} spacingX="3rem" spacingY="0.75rem">
+              <Box>
+                <FormLabel htmlFor="childName">NAME</FormLabel>
+                <Field
+                  as={CustomInput}
+                  id="childName"
+                  name="childName"
+                  type="string"
+                  placeholder="Enter name of child"
+                  icon={<Icon as={User} />}
+                  onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setChildDetails({
+                      ...childDetails,
+                      childName: e.target.value,
+                    })
+                  }
+                />
+              </Box>
+              <Box>
+                <FormLabel htmlFor="dateOfBirth">DATE OF BIRTH</FormLabel>
+                <Field
+                  as={CustomInput}
+                  name="dateOfBirth"
+                  id="dateOfBirth"
+                  type="string"
+                  placeholder="YYYY-MM-DD"
+                  icon={<Icon as={Calendar} />}
+                  onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setChildDetails({
+                      ...childDetails,
+                      dateOfBirth: e.target.value,
+                    })
+                  }
+                />
+              </Box>
+              <Box>
+                <FormLabel htmlFor="cpinFileNumber">
+                  CHILD FILE CPIN NUMBER
+                </FormLabel>
+                <Field
+                  as={CustomInput}
+                  id="cpinFileNumber"
+                  name="cpinFileNumber"
+                  type="string"
+                  placeholder="e.g. 123456789"
+                  icon={<Icon as={File} />}
+                  onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setChildDetails({
+                      ...childDetails,
+                      cpinFileNumber: e.target.value,
+                    })
+                  }
+                />
+              </Box>
+              <Box>
+                <FormLabel htmlFor="workerName">
+                  CHILDREN SERVICES OR KINSHIP WORKER <OptionalLabel />
+                </FormLabel>
+                <Field
+                  as={CustomInput}
+                  id="workerName"
+                  name="workerName"
+                  type="string"
+                  placeholder="Enter worker name"
+                  onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setChildDetails({
+                      ...childDetails,
+                      workerName: e.target.value,
+                    })
+                  }
+                />
+              </Box>
+            </SimpleGrid>
+            <Box paddingTop="10px">
+              <FormLabel htmlFor="specialNeeds">
+                SPECIAL NEEDS <OptionalLabel />
               </FormLabel>
               <Field
                 as={CustomInput}
-                id="cpinFileNumber"
-                name="cpinFileNumber"
+                id="specialNeeds"
+                name="specialNeeds"
                 type="string"
-                placeholder="e.g. 123456789"
-                icon={<Icon as={File} />}
+                placeholder="Enter any special needs of the child"
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    cpinFileNumber: e.target.value,
+                    specialNeeds: e.target.value,
                   })
                 }
               />
             </Box>
-            <Box>
-              <FormLabel htmlFor="workerName">
-                CHILDREN SERVICES OR KINSHIP WORKER <OptionalLabel />
+            <Box paddingTop="10px">
+              <FormLabel htmlFor="childBehaviours">
+                CHILD BEHAVIOURS AND CONCERNS <OptionalLabel />
               </FormLabel>
               <Field
                 as={CustomInput}
-                id="workerName"
-                name="workerName"
+                id="childBehaviours"
+                name="childBehaviours"
                 type="string"
-                placeholder="Enter worker name"
+                placeholder="Select or enter any behaviours and concerns to note"
                 onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
                   setChildDetails({
                     ...childDetails,
-                    workerName: e.target.value,
+                    childBehaviours: e.target.value,
                   })
                 }
               />
             </Box>
-          </SimpleGrid>
-          <Box paddingTop="10px">
-            <FormLabel htmlFor="specialNeeds">
-              SPECIAL NEEDS <OptionalLabel />
-            </FormLabel>
-            <Field
-              as={CustomInput}
-              id="specialNeeds"
-              name="specialNeeds"
-              type="string"
-              placeholder="Enter any special needs of the child"
-              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setChildDetails({
-                  ...childDetails,
-                  specialNeeds: e.target.value,
-                })
-              }
-            />
-          </Box>
-          <Box paddingTop="10px">
-            <FormLabel htmlFor="childBehaviours">
-              CHILD BEHAVIOURS AND CONCERNS <OptionalLabel />
-            </FormLabel>
-            <Field
-              as={CustomInput}
-              id="childBehaviours"
-              name="childBehaviours"
-              type="string"
-              placeholder="Select or enter any behaviours and concerns to note"
-              onKeyUp={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setChildDetails({
-                  ...childDetails,
-                  childBehaviours: e.target.value,
-                })
-              }
-            />
-          </Box>
-        </FormControl>
-      </Form>
-    </Formik>
+          </FormControl>
+        </Form>
+      </Formik>
+    </>
   );
 };
 

--- a/frontend/src/components/intake/child-information/SchoolDaycareForm.tsx
+++ b/frontend/src/components/intake/child-information/SchoolDaycareForm.tsx
@@ -32,7 +32,11 @@ const SchoolDaycareForm = ({
   };
 
   return (
-    <Formik initialValues={schoolDetails} onSubmit={onSubmit}>
+    <Formik
+      enableReinitialize
+      initialValues={schoolDetails}
+      onSubmit={onSubmit}
+    >
       <Form style={{ padding: "2rem 12rem" }}>
         <FormControl style={{ padding: "30px" }}>
           <SimpleGrid columns={2} spacingX="3rem" spacingY="0.75rem">
@@ -40,8 +44,8 @@ const SchoolDaycareForm = ({
               <FormLabel htmlFor="schoolName">NAME</FormLabel>
               <Field
                 as={CustomInput}
-                id="schooName"
-                name="schoolname"
+                id="schoolName"
+                name="schoolName"
                 type="string"
                 placeholder="Enter name of school or daycare"
                 icon={<Icon as={Home} />}

--- a/frontend/src/components/intake/indivDetails/CaregiverProviderForm.tsx
+++ b/frontend/src/components/intake/indivDetails/CaregiverProviderForm.tsx
@@ -7,7 +7,7 @@ import NewCaregiverModal, {
 } from "../NewCaregiverModal";
 import PromptBox, { IndividualDetailsOverview } from "../PromptBox";
 
-export type CaregiverFormProps = {
+type CaregiverFormProps = {
   caregivers: Caregivers;
   setCaregivers: React.Dispatch<React.SetStateAction<Caregivers>>;
 };

--- a/frontend/src/components/intake/indivDetails/ChildrenForm.tsx
+++ b/frontend/src/components/intake/indivDetails/ChildrenForm.tsx
@@ -1,21 +1,43 @@
-import React from "react";
+import React, { useState } from "react";
 import { UserPlus } from "react-feather";
 import { Icon } from "@chakra-ui/react";
 import { Children } from "../child-information/AddChildPage";
-import PromptBox from "../PromptBox";
+import PromptBox, { IndividualDetailsOverview } from "../PromptBox";
 import IntakeSteps from "../intakeSteps";
 
-export type ChildrenFormProps = {
+type ChildrenFormProps = {
   childrens: Children;
   setChildren: React.Dispatch<React.SetStateAction<Children>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedIndexChild: React.Dispatch<React.SetStateAction<number>>;
 };
 
 const ChildrenForm = ({
   childrens,
   setChildren,
   setStep,
+  setSelectedIndexChild,
 }: ChildrenFormProps): React.ReactElement => {
+  const [childrenDeleted, setChildrenDeleted] = useState(0);
+
+  const deleteChild = (index: number) => {
+    childrens.splice(index, 1);
+    // this isn't really useful, but it helps refresh the component
+    // ideally should have something useEffect, but current way of passing data does not work well with it
+    setChildrenDeleted(childrenDeleted + 1);
+    setChildren(childrens);
+  };
+
+  const childDetailsOverview: IndividualDetailsOverview[] = childrens.map(
+    (child) => {
+      const individualDetail: IndividualDetailsOverview = {
+        name: child.childDetails.childName,
+        fileNumber: child.childDetails.cpinFileNumber,
+      };
+      return individualDetail;
+    },
+  );
+
   return (
     <>
       <PromptBox
@@ -26,6 +48,9 @@ const ChildrenForm = ({
         onButtonClick={() => {
           setStep(IntakeSteps.ADD_CHILD);
         }}
+        individualDetails={childDetailsOverview}
+        deleteIndividual={deleteChild}
+        setSelectedIndex={setSelectedIndexChild}
       />
     </>
   );

--- a/frontend/src/components/intake/indivDetails/ChildrenForm.tsx
+++ b/frontend/src/components/intake/indivDetails/ChildrenForm.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { UserPlus } from "react-feather";
+import { Icon } from "@chakra-ui/react";
+import { Children } from "../child-information/AddChildPage";
+import PromptBox from "../PromptBox";
+import IntakeSteps from "../intakeSteps";
+
+export type ChildrenFormProps = {
+  childrens: Children;
+  setChildren: React.Dispatch<React.SetStateAction<Children>>;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const ChildrenForm = ({
+  childrens,
+  setChildren,
+  setStep,
+}: ChildrenFormProps): React.ReactElement => {
+  return (
+    <>
+      <PromptBox
+        headerText="Children"
+        descriptionText="No children have been added to the case yet. "
+        buttonText="Add child"
+        buttonIcon={<Icon as={UserPlus} w="16px" h="16px" />}
+        onButtonClick={() => {
+          setStep(IntakeSteps.ADD_CHILD);
+        }}
+      />
+    </>
+  );
+};
+
+export default ChildrenForm;

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -99,6 +99,8 @@ const Intake = (): React.ReactElement => {
           <IndividualDetailsEntry
             nextStep={nextStep}
             setStep={setStep}
+            childrens={children}
+            setChildren={setChildren}
             caregivers={caregivers}
             setCaregivers={setCaregivers}
           />

--- a/frontend/src/components/pages/IntakePage.tsx
+++ b/frontend/src/components/pages/IntakePage.tsx
@@ -71,6 +71,7 @@ const Intake = (): React.ReactElement => {
     setPermittedIndividuals,
   ] = useState<PermittedIndividuals>([]);
   const [allProviders, setAllProviders] = useState<Providers>([]);
+  const [selectedIndexChild, setSelectedIndexChild] = useState(-1);
 
   const nextStep = () => setStep(step + 1);
 
@@ -103,6 +104,8 @@ const Intake = (): React.ReactElement => {
             setChildren={setChildren}
             caregivers={caregivers}
             setCaregivers={setCaregivers}
+            selectedIndexChild={selectedIndexChild}
+            setSelectedIndexChild={setSelectedIndexChild}
           />
         );
       case IntakeSteps.PROGRAM_DETAILS:
@@ -195,6 +198,7 @@ const Intake = (): React.ReactElement => {
           setStep={setStep}
           childrens={children}
           setChildren={setChildren}
+          selectedIndexChild={selectedIndexChild}
         />
       ) : (
         <>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Individual details section “view and edit details” button for children](https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=85a193df9f5443718ca8383c0f1bcd45&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* after adding child from `add child` page, children should be displayed in intake page on indiv details section
* should be able to delete children from indiv details section
* should be able to view and edit details from indiv details section
     * prefill data for `child information`, `school/daycare`, and `providers`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go to `http://localhost:3000/intake`
2. add child


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* check if persists + deletes properly
* click on view and edit details, check if info is prefilled 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR