### PR TITLE
Main Dashboard GET Cases by Status with Pagination

### DIFF
--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -41,8 +41,20 @@ blueprint = Blueprint("intake", __name__, url_prefix="/intake")
 @blueprint.route("/", methods=["GET"], strict_slashes=False)
 # @require_authorization_by_role({"Admin"})
 def get_all_intakes():
+    args = request.args
+    intake_status = args.get("intake_status")
+    page_number = 1
     try:
-        intakes = intake_service.get_all_intakes()
+        page_number = int(args.get("page_number"))
+    except:
+        pass
+    page_limit = 20
+    try:
+        page_limit = int(args.get("page_limit"))
+    except:
+        pass
+    try:
+        intakes = intake_service.get_all_intakes(intake_status, page_number, page_limit)
         return jsonify(list(map(lambda intake: intake.__dict__, intakes))), 200
     except Exception as error:
         return jsonify(error), 400

--- a/backend/python/app/services/implementations/intake_service.py
+++ b/backend/python/app/services/implementations/intake_service.py
@@ -8,11 +8,14 @@ class IntakeService(IIntakeService):
     def __init__(self, logger):
         self.logger = logger
 
-    def get_all_intakes(self):
-        # FIXME: change this to match spec for actual get intakes method
+    def get_all_intakes(self, intake_status, page_number, page_limit=20):
+        start = (page_number - 1) * page_limit
+        end = page_number * page_limit
         try:
-            intakes = Intake.query.all()
-            intakes_dto = [IntakeDTO(**intake.to_dict()) for intake in intakes]
+            intakes = Intake.query.filter_by(intake_status=intake_status).all()
+            intakes_dto = [IntakeDTO(**intake.to_dict()) for intake in intakes][
+                start:end
+            ]
             return intakes_dto
         except Exception as error:
             self.logger.error(str(error))

--- a/backend/python/app/services/interfaces/intake_service.py
+++ b/backend/python/app/services/interfaces/intake_service.py
@@ -7,7 +7,7 @@ class IIntakeService(ABC):
     """
 
     @abstractmethod
-    def get_all_intakes(self):
+    def get_all_intakes(self, intake_status, page_number, page_limit=3):
         """
         Returns all intakes
         :rtype: list of IntakeDTO

--- a/backend/python/tests/functional/test_intake_service.py
+++ b/backend/python/tests/functional/test_intake_service.py
@@ -113,3 +113,131 @@ def test_missing_field(intake_service):
     param = CreateIntakeDTO(id=2)  # missing some required fields
     with pytest.raises(Exception):
         intake_service.create_intake(param)
+
+
+def test_get_intakes(intake_service):
+    intake_1 = CreateIntakeDTO(
+        id=2,
+        user_id=1,
+        intake_status="SUBMITTED",
+        referring_worker_name="Jane Doe2",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_2 = CreateIntakeDTO(
+        id=3,
+        user_id=1,
+        intake_status="ARCHIVED",
+        referring_worker_name="Jane Doe3",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_3 = CreateIntakeDTO(
+        id=4,
+        user_id=1,
+        intake_status="ACTIVE",
+        referring_worker_name="Jane Doe4",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_4 = CreateIntakeDTO(
+        id=5,
+        user_id=1,
+        intake_status="SUBMITTED",
+        referring_worker_name="Jane Doe5",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_5 = CreateIntakeDTO(
+        id=6,
+        user_id=1,
+        intake_status="SUBMITTED",
+        referring_worker_name="Jane Doe6",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_6 = CreateIntakeDTO(
+        id=7,
+        user_id=1,
+        intake_status="SUBMITTED",
+        referring_worker_name="Jane Doe7",
+        referring_worker_contact="1234567890",
+        referral_date="2020-01-01",
+        family_name="Doe",
+        cpin_number="1234567890",
+        cpin_file_type="INVESTIGATION",
+        court_status="OTHER",
+        court_order_file="1234567890",
+        transportation_requirements="1234567890",
+        scheduling_requirements="1234567890",
+        suggested_start_date="2020-01-01",
+    )
+
+    intake_service.create_intake(intake_1)
+    intake_service.create_intake(intake_2)
+    intake_service.create_intake(intake_3)
+    intake_service.create_intake(intake_4)
+    intake_service.create_intake(intake_5)
+
+    archived_intake_page_1 = intake_service.get_all_intakes("ARCHIVED", 1)
+    assert len(archived_intake_page_1) == 1
+
+    archived_intake_page_2 = intake_service.get_all_intakes("ARCHIVED", 2)
+    assert len(archived_intake_page_2) == 0
+
+    active_intake_page_1 = intake_service.get_all_intakes("ACTIVE", 1)
+    assert len(active_intake_page_1) == 1
+
+    active_intake_page_2 = intake_service.get_all_intakes("ACTIVE", 2)
+    assert len(active_intake_page_2) == 0
+
+    submitted_intake_page_1 = intake_service.get_all_intakes("SUBMITTED", 1, 3)
+    assert len(submitted_intake_page_1) == 3
+
+    submitted_intake_page_2 = intake_service.get_all_intakes("SUBMITTED", 2, 3)
+    assert len(submitted_intake_page_2) == 1


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Main Dashboard GET Cases by Status with Pagination](https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=d116ab525b8346759c7d8f7be420f02a&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* paginate/filter GET response for `intake_service` 
* added `intake_status` query parameter
* added `page_number` and `page_limit` parameters for pagination by offset


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. run unit tests:
  `docker exec -it cas_py_backend /bin/bash -c "pip install -e . && pytest"`

   or run `intake_service` in postman: 
   http://localhost:5000/intake?intake_status=ARCHIVED&page_number=1


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* `get_all_intakes` in services/implementations/intake_service.py
* `get_all_intakes` in rest/intake_routes.py


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
