### PR TITLE
Jackie/link case cards w status modal

### DIFF
--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -1,7 +1,10 @@
-import { Box, Text, Tag, Icon } from "@chakra-ui/react";
-import React from "react";
+import { Box, Text, Tag, Icon, useDisclosure } from "@chakra-ui/react";
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { ArrowUpRight } from "react-feather";
 import CaseStatus from "../../types/CaseStatus";
+import StatusModal from "./StatusModal";
+import PermanentDeleteModal from "./PermanentDeleteModal";
 
 export type CaseCardProps = {
   caseTitle: string;
@@ -32,54 +35,95 @@ const CaseCard = ({
   date,
   familyName,
   caseTag,
-}: CaseCardProps): React.ReactElement => (
-  <Box
-    as="button"
-    _hover={{ boxShadow: "md", borderWidth: "2px" }}
-    paddingRight="30px"
-    paddingLeft="30px"
-    width="297px"
-    height="289px"
-    borderWidth="1px"
-    borderRadius="lg"
-    onClick={
-      () => {} // TODO: FINISH THIS CALLBACK
-    }
-  >
-    <Box display="flex" justifyContent="space-between" textStyle="title-medium">
-      <Text textStyle="title-medium" marginBottom="15px">
-        {caseTitle}
-      </Text>
-      <Icon w="6" h="6" as={ArrowUpRight} />
-    </Box>
-    <Box
-      display="flex"
-      flexDirection="column"
-      alignItems="start"
-      marginBottom="10px"
-    >
-      <Text textStyle="body-medium" marginBottom="15px">
-        {caseLead}
-      </Text>
-      <Text textStyle="body-medium" marginBottom="15px">
-        {date}
-      </Text>
-      <Text textStyle="body-medium" marginBottom="25px">
-        {familyName}
-      </Text>
-    </Box>
-    <Box display="flex" justifyContent="end">
-      <Tag
-        pointerEvents="none"
-        backgroundColor={colorChange(caseTag)}
-        textColor="white"
-        borderWidth="0"
-        textStyle="button-medium"
+}: CaseCardProps): React.ReactElement => {
+  const {
+    onOpen: onOpenStatusModal,
+    isOpen: isOpenStatusModal,
+    onClose: onCloseStatusModal,
+  } = useDisclosure();
+
+  const {
+    onOpen: onOpenPermanentDelete,
+    isOpen: isOpenPermanentDelete,
+    onClose: onClosePermanentDelete,
+  } = useDisclosure();
+
+  const history = useHistory();
+  function goToIntake() {
+    history.push("/intake");
+  }
+
+  return (
+    <>
+      <Box
+        as="button"
+        _hover={{ boxShadow: "md", borderWidth: "2px" }}
+        paddingRight="30px"
+        paddingLeft="30px"
+        width="297px"
+        height="289px"
+        borderWidth="1px"
+        borderRadius="lg"
+        onClick={onOpenStatusModal}
       >
-        {caseTag.toUpperCase()}
-      </Tag>
-    </Box>
-  </Box>
-);
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          textStyle="title-medium"
+        >
+          <Text textStyle="title-medium" marginBottom="15px">
+            {caseTitle}
+          </Text>
+          <Icon w="6" h="6" as={ArrowUpRight} />
+        </Box>
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="start"
+          marginBottom="10px"
+        >
+          <Text textStyle="body-medium" marginBottom="15px">
+            {caseLead}
+          </Text>
+          <Text textStyle="body-medium" marginBottom="15px">
+            {date}
+          </Text>
+          <Text textStyle="body-medium" marginBottom="25px">
+            {familyName}
+          </Text>
+        </Box>
+        <Box display="flex" justifyContent="end">
+          <Tag
+            pointerEvents="none"
+            backgroundColor={colorChange(caseTag)}
+            textColor="white"
+            borderWidth="0"
+            textStyle="button-medium"
+          >
+            {caseTag.toUpperCase()}
+          </Tag>
+        </Box>
+      </Box>
+      <PermanentDeleteModal
+        isOpen={isOpenPermanentDelete}
+        onClick={() => {
+          // TODO: add deletion logic
+          onClosePermanentDelete();
+          onCloseStatusModal();
+        }}
+        onClose={onClosePermanentDelete}
+      />
+      <StatusModal
+        caseNumber={1}
+        status="ARCHIVED"
+        isOpen={isOpenStatusModal}
+        onClick={() => {}}
+        onClose={onCloseStatusModal}
+        onDeleteClick={onOpenPermanentDelete}
+        goToIntake={goToIntake}
+      />
+    </>
+  );
+};
 
 export default CaseCard;

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Box, Text, Tag, Icon, useDisclosure } from "@chakra-ui/react";
 import { useHistory } from "react-router-dom";
 import { ArrowUpRight } from "react-feather";

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, Tag, Icon, useDisclosure } from "@chakra-ui/react";
-import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { ArrowUpRight } from "react-feather";
 import CaseStatus from "../../types/CaseStatus";

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -112,6 +112,7 @@ const CaseCard = ({
           onCloseStatusModal();
         }}
         onClose={onClosePermanentDelete}
+        intakeId={2} // TODO implement so that this componet gets passed in real intakeId
       />
       <StatusModal
         caseId={caseId}

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -116,7 +116,7 @@ const CaseCard = ({
       />
       <StatusModal
         caseId={caseId}
-        status="ARCHIVED"
+        status={caseTag.toUpperCase()}
         isOpen={isOpenStatusModal}
         onClick={() => {}}
         onClose={onCloseStatusModal}

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -7,7 +7,7 @@ import StatusModal from "./StatusModal";
 import PermanentDeleteModal from "./PermanentDeleteModal";
 
 export type CaseCardProps = {
-  caseTitle: string;
+  caseId: number;
   caseLead: string;
   date: string;
   familyName: string;
@@ -30,7 +30,7 @@ const colorChange = (value: string) => {
 };
 
 const CaseCard = ({
-  caseTitle,
+  caseId,
   caseLead,
   date,
   familyName,
@@ -72,7 +72,7 @@ const CaseCard = ({
           textStyle="title-medium"
         >
           <Text textStyle="title-medium" marginBottom="15px">
-            {caseTitle}
+            Case {caseId}
           </Text>
           <Icon w="6" h="6" as={ArrowUpRight} />
         </Box>
@@ -114,7 +114,7 @@ const CaseCard = ({
         onClose={onClosePermanentDelete}
       />
       <StatusModal
-        caseNumber={1}
+        caseId={caseId}
         status="ARCHIVED"
         isOpen={isOpenStatusModal}
         onClick={() => {}}

--- a/frontend/src/components/dashboard/FilteredSection.tsx
+++ b/frontend/src/components/dashboard/FilteredSection.tsx
@@ -44,8 +44,8 @@ const FilteredSection = ({
             {cases.slice(0, 4).map((caseData: CaseCardProps) => {
               return (
                 <CaseCard
-                  key={caseData.caseTitle}
-                  caseTitle={caseData.caseTitle}
+                  key={caseData.caseId}
+                  caseId={caseData.caseId}
                   caseLead={caseData.caseLead}
                   date={caseData.date}
                   familyName={caseData.familyName}

--- a/frontend/src/components/dashboard/StatusModal.tsx
+++ b/frontend/src/components/dashboard/StatusModal.tsx
@@ -18,7 +18,7 @@ import { StatusSelectField } from "./StatusSelectField";
 import { useStepValueContext } from "../../contexts/IntakeValueContext";
 
 export type StatusModalProps = {
-  caseNumber?: number;
+  caseId?: number;
   status: string;
   isOpen: boolean;
   onClick: () => void;
@@ -28,7 +28,7 @@ export type StatusModalProps = {
 };
 
 const StatusModal = ({
-  caseNumber,
+  caseId,
   status,
   isOpen,
   onClose,
@@ -84,7 +84,7 @@ const StatusModal = ({
   return (
     <Box>
       <ModalComponent
-        primaryTitle={`Case ${caseNumber}`}
+        primaryTitle={`Case ${caseId}`}
         secondaryTitle=""
         showLeftButton={selectedOption === "ARCHIVED"}
         leftButtonTitle="Delete"

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -82,7 +82,7 @@ const SecondaryHeader = (): React.ReactElement => {
         {/* //TODO: dynamically pass in case details 
         and add onClick save functionality */}
         <StatusModal
-          caseNumber={1}
+          caseId={1}
           status="ARCHIVED"
           isOpen={isOpenStatusModal}
           onClick={() => {}}
@@ -99,28 +99,28 @@ const Home = (): React.ReactElement => {
   const cases: { [key: string]: CaseCardProps[] } = {
     active: [
       {
-        caseTitle: "Case 1",
+        caseId: 1,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
         caseTag: CaseStatus.ACTIVE,
       },
       {
-        caseTitle: "Case 2",
+        caseId: 2,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
         caseTag: CaseStatus.ACTIVE,
       },
       {
-        caseTitle: "Case 3",
+        caseId: 3,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
         caseTag: CaseStatus.ACTIVE,
       },
       {
-        caseTitle: "Case 1",
+        caseId: 4,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
@@ -129,7 +129,7 @@ const Home = (): React.ReactElement => {
     ],
     submitted: [
       {
-        caseTitle: "Case 1",
+        caseId: 5,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
@@ -138,7 +138,7 @@ const Home = (): React.ReactElement => {
     ],
     pending: [
       {
-        caseTitle: "Case 1",
+        caseId: 1,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
@@ -147,7 +147,7 @@ const Home = (): React.ReactElement => {
     ],
     archived: [
       {
-        caseTitle: "Case 1",
+        caseId: 1,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -25,18 +25,6 @@ const SecondaryHeader = (): React.ReactElement => {
     history.push("/intake");
   }
 
-  const {
-    onOpen: onOpenPermanentDelete,
-    isOpen: isOpenPermanentDelete,
-    onClose: onClosePermanentDelete,
-  } = useDisclosure();
-
-  const {
-    onOpen: onOpenStatusModal,
-    isOpen: isOpenStatusModal,
-    onClose: onCloseStatusModal,
-  } = useDisclosure();
-
   return (
     <Box>
       <Text textStyle="header-large">Intake Cases</Text>
@@ -58,38 +46,6 @@ const SecondaryHeader = (): React.ReactElement => {
         >
           New case
         </Button>
-
-        <Button
-          height="100%"
-          px="2"
-          rounded="lg"
-          border="1px"
-          onClick={onOpenStatusModal}
-        >
-          Test Status Modal
-        </Button>
-
-        <PermanentDeleteModal
-          isOpen={isOpenPermanentDelete}
-          onClick={() => {
-            // TODO: add deletion logic
-            onClosePermanentDelete();
-            onCloseStatusModal();
-          }}
-          onClose={onClosePermanentDelete}
-          intakeId={2} // TODO implement so that this componet gets passed in real intakeId
-        />
-        {/* //TODO: dynamically pass in case details 
-        and add onClick save functionality */}
-        <StatusModal
-          caseId={1}
-          status="ARCHIVED"
-          isOpen={isOpenStatusModal}
-          onClick={() => {}}
-          onClose={onCloseStatusModal}
-          onDeleteClick={onOpenPermanentDelete}
-          goToIntake={goToIntake}
-        />
       </Flex>
     </Box>
   );
@@ -138,7 +94,7 @@ const Home = (): React.ReactElement => {
     ],
     pending: [
       {
-        caseId: 1,
+        caseId: 6,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
@@ -147,7 +103,7 @@ const Home = (): React.ReactElement => {
     ],
     archived: [
       {
-        caseId: 1,
+        caseId: 7,
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -106,14 +106,14 @@ const Home = (): React.ReactElement => {
         caseTag: CaseStatus.ACTIVE,
       },
       {
-        caseTitle: "Case 1",
+        caseTitle: "Case 2",
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",
         caseTag: CaseStatus.ACTIVE,
       },
       {
-        caseTitle: "Case 1",
+        caseTitle: "Case 3",
         caseLead: "Case Lead",
         date: "11/06/2023",
         familyName: "Family Name",

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -7,7 +7,6 @@ import {
   Spacer,
   VStack,
   Text,
-  useDisclosure,
 } from "@chakra-ui/react";
 import { useHistory } from "react-router-dom";
 import { FilePlus, Search } from "react-feather";
@@ -15,8 +14,6 @@ import CustomInput from "../common/CustomInput";
 import IntakeHeader from "../intake/IntakeHeader";
 import CaseStatus from "../../types/CaseStatus";
 import FilteredSection from "../dashboard/FilteredSection";
-import StatusModal from "../dashboard/StatusModal";
-import PermanentDeleteModal from "../dashboard/PermanentDeleteModal";
 import { CaseCardProps } from "../dashboard/CaseCard";
 
 const SecondaryHeader = (): React.ReactElement => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Link Case Cards with Case Status modal](https://www.notion.so/uwblueprintexecs/Link-Case-Cards-with-Case-Status-modal-4bc9b86f4b2b499db11595f7164d52f7?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Implemented logic so that when you click on case card, it opens case status modal
* Removed Test Status Modal button on Home Page
* Refactored code so that instead of "CaseTitle" it is now called caseId so that when we connect to backend, we can just pass caseId into the permanent delete modal

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Click on Case Card 
2. verify case status modal opens 
3. verify that the id on the modal matches id of card that you click on 
4. verify that you can open permanent delete modal


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
*  That case status modal opens and the title in status modal matches the title in the CaseCard


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
