### PR TITLE
Refactor case over routing to display proper case data

### DIFF
--- a/backend/python/app/services/implementations/intake_service.py
+++ b/backend/python/app/services/implementations/intake_service.py
@@ -86,6 +86,8 @@ class IntakeService(IIntakeService):
                 intake.lead_access_worker_name = updated_data["lead_access_worker_name"]
             if "intake_meeting_notes" in updated_data:
                 intake.intake_meeting_notes = updated_data["intake_meeting_notes"]
+            if "referring_worker_name" in updated_data:
+                intake.referring_worker_name = updated_data["referring_worker_name"]
             db.session.commit()
             return IntakeDTO(**intake.to_dict())
         except Exception as error:

--- a/backend/python/tools/db_seed.py
+++ b/backend/python/tools/db_seed.py
@@ -56,19 +56,19 @@ def insert_test_data():
 
     # Intakes
     values = [
-        (1, "ARCHIVED", "Arya Stark", "aryastark@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ARCHIVED", "Bran Stark", "branstark@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ARCHIVED", "Jon Snow", "jonsnow@mail.com", "2020-01-01", "Snow", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ARCHIVED", "Samwell Tarly", "samwelltarly@mail.com", "2020-01-01", "Tarly", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ACTIVE", "Billy Bob", "billybob@mail.com", "2020-01-01", "Bob", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ACTIVE", "Jonathan Johns", "jonjohns@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "ACTIVE", "Peter Parker", "peterparker@mail.com", "2020-01-01", "Snow", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "PENDING", "Matthew McDonald", "matthewmcdonald@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
-        (1, "PENDING", "Lily Li", "Lily Li@mail.com", "2020-01-01", "Tarly", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01"),
+        (1, "ARCHIVED", "Arya Stark", "aryastark@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "John", "n/a"),
+        (1, "ARCHIVED", "Bran Stark", "branstark@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Mary", "n/a"),
+        (1, "ARCHIVED", "Jon Snow", "jonsnow@mail.com", "2020-01-01", "Snow", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Grey", "n/a"),
+        (1, "ARCHIVED", "Samwell Tarly", "samwelltarly@mail.com", "2020-01-01", "Tarly", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01","2023-01-01", "Kings Landing", "Jim", "n/a"),
+        (1, "ACTIVE", "Billy Bob", "billybob@mail.com", "2020-01-01", "Bob", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Mike", "n/a"),
+        (1, "ACTIVE", "Jonathan Johns", "jonjohns@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Sarah", "n/a"),
+        (1, "ACTIVE", "Peter Parker", "peterparker@mail.com", "2020-01-01", "Snow", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01",  "2023-01-01", "Kings Landing", "Julia", "n/a", ),
+        (1, "PENDING", "Matthew McDonald", "matthewmcdonald@mail.com", "2020-01-01", "Stark", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Samantha", "n/a"),
+        (1, "PENDING", "Lily Li", "Lily Li@mail.com", "2020-01-01", "Tarly", "123456789", "ONGOING", "OTHER", "court_order_file.pdf", "UNKNOWN", "", "transportation_requirements", "scheduling_requirements", "2020-01-01", "2023-01-01", "Kings Landing", "Noah","n/a"),
     ]
 
     for value in values:
-        insert_values(db, "intakes", ("user_id", "intake_status", "referring_worker_name", "referring_worker_contact", "referral_date", "family_name", "cpin_number", "cpin_file_type", "court_status", "court_order_file", "first_nation_heritage", "first_nation_band", "transportation_requirements", "scheduling_requirements", "suggested_start_date", "date_accepted", "access_location", "lead_access_worker_id", "denial_reason", "lead_access_worker_name"), value)
+        insert_values(db, "intakes", ("user_id", "intake_status", "referring_worker_name", "referring_worker_contact", "referral_date", "family_name", "cpin_number", "cpin_file_type", "court_status", "court_order_file", "first_nation_heritage", "first_nation_band", "transportation_requirements", "scheduling_requirements", "suggested_start_date", "date_accepted", "access_location", "lead_access_worker_name", "denial_reason","lead_access_worker_id"), value)
 
     # Daytime Contact
     values = [
@@ -109,6 +109,7 @@ def insert_test_data():
 
     for value in values:
         insert_values(db, "other_permitted_individuals", ("name", "phone_number", "relationship_to_child", "notes", "intake_id"), value)
+        
 
     # Providers
     values = [

--- a/frontend/src/components/dashboard/CaseCard.tsx
+++ b/frontend/src/components/dashboard/CaseCard.tsx
@@ -57,7 +57,10 @@ const CaseCard = ({
   // TODO refactor to display proper case data
   const onCardClick = (status: string) => {
     if (status === "ACTIVE") {
-      history.push(`/caseoverview`);
+      history.push({
+        pathname: `/caseoverview/${caseId}`,
+        state: { caseLead },
+      });
     } else {
       onOpenStatusModal();
     }

--- a/frontend/src/components/pages/CaseOverview.tsx
+++ b/frontend/src/components/pages/CaseOverview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams, useLocation} from "react-router-dom";
 import {
   Box,
   Button,
@@ -16,8 +16,14 @@ import VisitCadenceModal from "../dashboard/VisitCadenceModal";
 import intakeAPIClient from "../../APIClients/IntakeAPIClient";
 
 const CaseOverviewBody = (): React.ReactElement => {
-  const [leadName, setLeadName] = useState("");
   const history = useHistory();
+  const { id } = useParams<{ id: string}>();
+  const caseNumber : number = parseInt(id, 10);
+
+  const {state} = useLocation<{caseLead: string}>();
+  const {caseLead} = state;
+
+  const [leadName, setLeadName] = useState(caseLead);
 
   const {
     onOpen: onOpenVisitCadenceModal,
@@ -34,7 +40,7 @@ const CaseOverviewBody = (): React.ReactElement => {
     history.push("/");
   };
   const changeLead = async () => {
-    const intakeID = 1; // TODO replace with actual intake id
+    const intakeID = caseNumber; 
     const changedData: Record<string, string> = {
       lead_access_worker_name: leadName,
     };
@@ -317,7 +323,7 @@ const CaseOverviewBody = (): React.ReactElement => {
         </Flex>
       </Flex>
       <VisitCadenceModal
-        caseNumber={1} // TODO pass actual case data
+        caseNumber={caseNumber}
         status="ARCHIVED"
         isOpen={isOpenVisitCadenceModal}
         onClick={() => {}}
@@ -331,10 +337,12 @@ const CaseOverviewBody = (): React.ReactElement => {
 };
 
 const CaseOverview = (): React.ReactElement => {
+  const { id } = useParams<{ id: string }>();
+
   return (
     <Box>
       <IntakeHeader
-        primaryTitle="Case Name"
+        primaryTitle={`Case ${id}`}
         secondaryTitle="Case Management"
         hasLogout
       />

--- a/frontend/src/components/pages/CaseOverview.tsx
+++ b/frontend/src/components/pages/CaseOverview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useHistory, useParams, useLocation} from "react-router-dom";
+import { useHistory, useParams, useLocation } from "react-router-dom";
 import {
   Box,
   Button,
@@ -17,11 +17,11 @@ import intakeAPIClient from "../../APIClients/IntakeAPIClient";
 
 const CaseOverviewBody = (): React.ReactElement => {
   const history = useHistory();
-  const { id } = useParams<{ id: string}>();
-  const caseNumber : number = parseInt(id, 10);
+  const { id } = useParams<{ id: string }>();
+  const caseNumber: number = parseInt(id, 10);
 
-  const {state} = useLocation<{caseLead: string}>();
-  const {caseLead} = state;
+  const { state } = useLocation<{ caseLead: string }>();
+  const { caseLead } = state;
 
   const [leadName, setLeadName] = useState(caseLead);
 
@@ -40,7 +40,7 @@ const CaseOverviewBody = (): React.ReactElement => {
     history.push("/");
   };
   const changeLead = async () => {
-    const intakeID = caseNumber; 
+    const intakeID = caseNumber;
     const changedData: Record<string, string> = {
       lead_access_worker_name: leadName,
     };

--- a/frontend/src/components/pages/CaseOverview.tsx
+++ b/frontend/src/components/pages/CaseOverview.tsx
@@ -42,7 +42,7 @@ const CaseOverviewBody = (): React.ReactElement => {
   const changeLead = async () => {
     const intakeID = caseNumber;
     const changedData: Record<string, string> = {
-      lead_access_worker_name: leadName,
+      referringWorkerName: leadName,
     };
     try {
       const result = await intakeAPIClient.put({ changedData, intakeID });

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -4,7 +4,7 @@ export const VISIT_PAGE = "/visit";
 export const LOGIN_PAGE = "/login";
 export const SIGNUP_PAGE = "/signup";
 export const CASES_PAGE = "/cases";
-export const CASEOVERVIEW_PAGE = "/caseoverview";
+export const CASEOVERVIEW_PAGE = "/caseoverview/:id";
 
 // TODO: Delete these
 export const EDIT_TEAM_PAGE = "/edit-team";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Refactor case overview routing to display proper case data](https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=ec2d157a050d4c6b86a4da52a926f494&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Used useLocation(), & useParams() hook to implement dynamic routing for case overview and read case parameters ie. caseLead


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Check that corresponding case number show up correctly when on case overview
2. Verify that dynamic route matches case number selected
3. Verify that correct caseLead is working


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Unsure about sustainability of pulling case data from useLocation hook instead of using intake service (GET request). No method currently exists for fetching data on singular case 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
