### PR TITLE
Fix edit caregiver to delete logic

### DIFF
--- a/frontend/src/components/intake/indivDetails/CaregiverProviderForm.tsx
+++ b/frontend/src/components/intake/indivDetails/CaregiverProviderForm.tsx
@@ -39,6 +39,7 @@ const CaregiverForm = ({
     // ideally should have something useEffect, but current way of passing data does not work well with it
     setCaregiversDeleted(caregiversDeleted + 1);
     setCaregivers(caregivers);
+    setSelectedIndex(-1);
   };
 
   const caregiverDetailsOverview: IndividualDetailsOverview[] = caregivers.map(


### PR DESCRIPTION
## Notion ticket link
- Not a ticket, but noticed that after clicking `view and edit details` and trying to delete a caregiver, app crashes

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
- Had something todo with accessing an undefined caregiver based on the `selectedIndex` state
- Decided to reset the index each time caregiver is deleted, to avoid accessing undefined caregiver array indexes


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
