### PR TITLE
Fill in Additional Fields and Restructuring Object for GET Intake 

### DIFF
--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -55,6 +55,26 @@ def get_all_intakes():
     try:
         intakes = intake_service.get_all_intakes(intake_status, page_number, page_limit)
         for intake in intakes:
+            caseReferral = {
+                "referringWorker": intake.referring_worker_name,
+                "referringWorkerContact": intake.referring_worker_contact,
+                "cpinFileNumber": intake.cpin_number,
+                "cpinFileType": intake.cpin_file_type,
+                "familyName": intake.family_name,
+                "referralDate": intake.referral_date,
+            }
+
+            intake.caseReferral = caseReferral
+
+            courtInformation = {
+                "courtStatus": intake.court_status,
+                "orderReferral": intake.court_order_file,
+                "firstNationHeritage": intake.first_nation_heritage,
+                "firstNationBand": intake.first_nation_band,
+            }
+
+            intake.courtInformation = courtInformation
+
             caregivers_dtos = caregiver_service.get_caregivers_by_intake_id(intake.id)
             caregivers = []
             for caregiver in caregivers_dtos:
@@ -135,7 +155,7 @@ def get_all_intakes():
                 "longTermGoals": goal_service.get_goal_names_by_intake(
                     intake.id, "LONG_TERM"
                 ),
-                "familialConcerns": [],
+                "familialConcerns": [], #familialConcern_service.get_familial_concerns_str_by_intake(intake.id),
                 "permittedIndividuals": new_opis,
             }
             intake.programDetails = program_details

--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -101,7 +101,7 @@ def get_all_intakes():
                     "cpinFileNumber": child.cpin_number,
                     "serviceWorker": child.service_worker,
                     "specialNeeds": child.special_needs,
-                    "concerns": [],
+                    "concerns": childBehavior_service.get_concerns_str_by_child(child.id),
                 }
 
                 daytime_contact = (

--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -70,7 +70,6 @@ def get_all_intakes():
                     "additionalContactNotes": caregiver.additional_contact_notes,
                 }
                 caregivers.append(caregiver_obj)
-            intake.caregivers = caregivers
 
             just_children = child_service.get_children_by_intake_id(intake.id)
             new_children = []
@@ -130,7 +129,7 @@ def get_all_intakes():
             intake_new = {
                 "user_id": intake.user_id,
                 "case_id": intake.id,
-                "intake_status": "ACTIVE",
+                "intake_status": intake.intake_status,
                 "caseReferral": {
                     "referringWorker": intake.referring_worker_name,
                     "referringWorkerContact": intake.referring_worker_contact,
@@ -146,7 +145,7 @@ def get_all_intakes():
                     "firstNationBand": intake.first_nation_band,
                 },
                 "children": new_children,
-                "caregivers": [],
+                "caregivers": caregivers,
                 "programDetails": {
                     "transportationRequirements": intake.transportation_requirements,
                     "schedulingRequirements": intake.scheduling_requirements,

--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -54,27 +54,8 @@ def get_all_intakes():
         pass
     try:
         intakes = intake_service.get_all_intakes(intake_status, page_number, page_limit)
+        intake_new_list = []
         for intake in intakes:
-            caseReferral = {
-                "referringWorker": intake.referring_worker_name,
-                "referringWorkerContact": intake.referring_worker_contact,
-                "cpinFileNumber": intake.cpin_number,
-                "cpinFileType": intake.cpin_file_type,
-                "familyName": intake.family_name,
-                "referralDate": intake.referral_date,
-            }
-
-            intake.caseReferral = caseReferral
-
-            courtInformation = {
-                "courtStatus": intake.court_status,
-                "orderReferral": intake.court_order_file,
-                "firstNationHeritage": intake.first_nation_heritage,
-                "firstNationBand": intake.first_nation_band,
-            }
-
-            intake.courtInformation = courtInformation
-
             caregivers_dtos = caregiver_service.get_caregivers_by_intake_id(intake.id)
             caregivers = []
             for caregiver in caregivers_dtos:
@@ -132,7 +113,6 @@ def get_all_intakes():
                 }
 
                 new_children.append(new_child)
-            intake.children = new_children
 
             opis = permittedIndividual_service.get_other_permitted_individuals_by_intake_id(
                 intake.id
@@ -147,22 +127,46 @@ def get_all_intakes():
                 }
                 new_opis.append(new_opi)
 
-            program_details = {
-                "transportRequirements": intake.transportation_requirements,
-                "schedulingRequirements": intake.scheduling_requirements,
-                "suggestedStartDate": intake.suggested_start_date,
-                "shortTermGoals": goal_service.get_goal_names_by_intake(
-                    intake.id, "SHORT_TERM"
-                ),
-                "longTermGoals": goal_service.get_goal_names_by_intake(
-                    intake.id, "LONG_TERM"
-                ),
-                "familialConcerns": [],  # familialConcern_service.get_familial_concerns_str_by_intake(intake.id),
-                "permittedIndividuals": new_opis,
+            intake_new = {
+                "user_id": intake.user_id,
+                "case_id": intake.id,
+                "intake_status": "ACTIVE",
+                "caseReferral": {
+                    "referringWorker": intake.referring_worker_name,
+                    "referringWorkerContact": intake.referring_worker_contact,
+                    "cpinFileNumber": intake.cpin_number,
+                    "cpinFileType": intake.cpin_file_type,
+                    "familyName": intake.family_name,
+                    "referralDate": intake.referral_date,
+                },
+                "courtInformation": {
+                    "courtStatus": intake.court_status,
+                    "orderReferral": intake.court_order_file,
+                    "firstNationHeritage": intake.first_nation_heritage,
+                    "firstNationBand": intake.first_nation_band,
+                },
+                "children": new_children,
+                "caregivers": [],
+                "programDetails": {
+                    "transportationRequirements": intake.transportation_requirements,
+                    "schedulingRequirements": intake.scheduling_requirements,
+                    "suggestedStartDate": intake.suggested_start_date,
+                    "shortTermGoals": goal_service.get_goal_names_by_intake(
+                        intake.id, "SHORT_TERM"
+                    ),
+                    "longTermGoals": goal_service.get_goal_names_by_intake(
+                        intake.id, "LONG_TERM"
+                    ),
+                    "familialConcerns": familialConcern_service.get_familial_concerns_str_by_intake(
+                        intake.id
+                    ),
+                    "permittedIndividuals": new_opis,
+                },
             }
-            intake.programDetails = program_details
 
-        return jsonify(list(map(lambda intake: intake.__dict__, intakes))), 200
+            intake_new_list.append(intake_new)
+
+        return jsonify(intake_new_list), 200
     except Exception as error:
         return jsonify(error), 400
 

--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -101,7 +101,9 @@ def get_all_intakes():
                     "cpinFileNumber": child.cpin_number,
                     "serviceWorker": child.service_worker,
                     "specialNeeds": child.special_needs,
-                    "concerns": childBehavior_service.get_concerns_str_by_child(child.id),
+                    "concerns": childBehavior_service.get_concerns_str_by_child(
+                        child.id
+                    ),
                 }
 
                 daytime_contact = (
@@ -155,7 +157,7 @@ def get_all_intakes():
                 "longTermGoals": goal_service.get_goal_names_by_intake(
                     intake.id, "LONG_TERM"
                 ),
-                "familialConcerns": [], #familialConcern_service.get_familial_concerns_str_by_intake(intake.id),
+                "familialConcerns": [],  # familialConcern_service.get_familial_concerns_str_by_intake(intake.id),
                 "permittedIndividuals": new_opis,
             }
             intake.programDetails = program_details

--- a/backend/python/app/rest/intake_routes.py
+++ b/backend/python/app/rest/intake_routes.py
@@ -126,9 +126,9 @@ def get_all_intakes():
                 new_opis.append(new_opi)
 
             program_details = {
-                "transportRequirements": "",
-                "schedulingRequirements": "",
-                "suggestedStartDate": "",
+                "transportRequirements": intake.transportation_requirements,
+                "schedulingRequirements": intake.scheduling_requirements,
+                "suggestedStartDate": intake.suggested_start_date,
                 "shortTermGoals": goal_service.get_goal_names_by_intake(
                     intake.id, "SHORT_TERM"
                 ),

--- a/backend/python/app/services/implementations/child_behavior_service.py
+++ b/backend/python/app/services/implementations/child_behavior_service.py
@@ -35,8 +35,7 @@ class ChildBehaviorService(IChildBehaviorService):
         try:
             child = Child.query.filter_by(id=child_id).first()
             concerns = [
-                ChildBehaviorDTO(**result.to_dict())
-                for result in child.behaviors
+                ChildBehaviorDTO(**result.to_dict()) for result in child.behaviors
             ]
             concern_strings = [concern_obj.behavior for concern_obj in concerns]
             return concern_strings

--- a/backend/python/app/services/implementations/child_behavior_service.py
+++ b/backend/python/app/services/implementations/child_behavior_service.py
@@ -31,6 +31,19 @@ class ChildBehaviorService(IChildBehaviorService):
             self.logger.error(str(error))
             raise error
 
+    def get_concerns_str_by_child(self, child_id: int):
+        try:
+            child = Child.query.filter_by(id=child_id).first()
+            concerns = [
+                ChildBehaviorDTO(**result.to_dict())
+                for result in child.behaviors
+            ]
+            concern_strings = [concern_obj.behavior for concern_obj in concerns]
+            return concern_strings
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+
     def get_all_child_behaviors(self, is_default=True):
         try:
             return [

--- a/backend/python/app/services/implementations/familial_concern_service.py
+++ b/backend/python/app/services/implementations/familial_concern_service.py
@@ -45,6 +45,19 @@ class FamilialConcernService(IFamilialConcernService):
             self.logger.error(str(error))
             raise error
 
+    def get_familial_concerns_str_by_intake(self, intake_id: int):
+        try:
+            intake_instance = Intake.query.filter_by(id=intake_id).first()
+            familial_concerns = [
+                FamilialConcernDTO(**result.to_dict())
+                for result in intake_instance.concerns
+            ]
+            concern_strings = [concern_obj.concern for concern_obj in familial_concerns]
+            return concern_strings
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+
     def add_familial_concern(self, concern: str, is_default=False):
         try:
             new_familial_concern_entry = FamilialConcern(

--- a/backend/python/app/services/interfaces/child_behavior_service.py
+++ b/backend/python/app/services/interfaces/child_behavior_service.py
@@ -51,3 +51,12 @@ class IChildBehaviorService(ABC):
         :raises Exception: if an error occurs on the database side
         """
         pass
+
+    def get_concerns_str_by_child(self, child_id: int):
+        """Get behavior concerns as strings for a given child_id
+
+        :param child_id: int of Child id
+        :return: list of strings
+        :raises Exception: if child_id is invalid or any error occurs
+        """
+        pass   

--- a/backend/python/app/services/interfaces/child_behavior_service.py
+++ b/backend/python/app/services/interfaces/child_behavior_service.py
@@ -59,4 +59,4 @@ class IChildBehaviorService(ABC):
         :return: list of strings
         :raises Exception: if child_id is invalid or any error occurs
         """
-        pass   
+        pass

--- a/backend/python/app/services/interfaces/familial_concern_service.py
+++ b/backend/python/app/services/interfaces/familial_concern_service.py
@@ -55,3 +55,12 @@ class IFamilialConcernService(ABC):
         :raises Exception: if an error occurs on the database side
         """
         pass
+
+    def get_concerns_str_by_child(self, child_id: int):
+        """Get behavior concerns as strings for a given child_id
+
+        :param child_id: int of Child id
+        :return: list of strings
+        :raises Exception: if child_id is invalid or any error occurs
+        """
+        pass

--- a/frontend/src/APIClients/IntakeAPIClient.ts
+++ b/frontend/src/APIClients/IntakeAPIClient.ts
@@ -6,20 +6,27 @@ import CaseStatus from "../types/CaseStatus";
 
 interface Intake {
   user_id: number;
-  id: number;
-  referring_worker_name: string;
-  referring_worker_contact: string;
-  cpin_number: string;
-  cpin_file_type: string;
-  family_name: string;
+  case_id: number;
   intake_status: string;
-  referral_date: string;
-  court_status: string;
-  first_nation_heritage: string;
-  first_nation_band: string;
-  transportation_requirements: string;
-  scheduling_requirements: string;
-  suggested_start_date: string;
+  caseReferral: {
+    referringWorkerName: string;
+    referringWorkerContact: string;
+    cpinFileNumber: string;
+    cpinFileType: string;
+    familyName: string;
+    referralDate: string;
+  };
+  courtInformation: {
+    courtStatus: string;
+    orderReferral: string;
+    firstNationHeritage: string;
+    firstNationBand: string;
+  };
+  programDetails: {
+    transportationRequirements: string;
+    schedulingRequirements: string;
+    suggestedStartDate: string;
+  };
 }
 
 const post = async ({ formData }: { formData: FormData }): Promise<Case> => {
@@ -58,23 +65,23 @@ const get = async (
 
     const mappedData: Case[] = data.map((intake) => ({
       user_id: intake.user_id.toString(),
-      case_id: intake.id.toString(),
+      case_id: intake.case_id.toString(),
       intakeStatus: <CaseStatus>intake.intake_status,
       caseReferral: {
-        referringWorkerName: intake.referring_worker_name,
-        referringWorkerContact: intake.referring_worker_contact,
-        cpinFileNumber: parseInt(intake.cpin_number, 20),
-        cpinFileType: intake.cpin_file_type,
-        familyName: intake.family_name,
-        referralDate: new Date(intake.referral_date).toLocaleDateString(
-          "en-GB",
-        ),
+        referringWorkerName: intake.caseReferral.referringWorkerName,
+        referringWorkerContact: intake.caseReferral.referringWorkerContact,
+        cpinFileNumber: parseInt(intake.caseReferral.cpinFileNumber, 20),
+        cpinFileType: intake.caseReferral.cpinFileType,
+        familyName: intake.caseReferral.familyName,
+        referralDate: new Date(
+          intake.caseReferral.referralDate,
+        ).toLocaleDateString("en-GB"),
       },
       courtInformation: {
-        courtStatus: intake.court_status,
+        courtStatus: intake.courtInformation.courtStatus,
         orderReferral: 0,
-        firstNationHeritage: intake.first_nation_heritage,
-        firstNationBand: intake.first_nation_band,
+        firstNationHeritage: intake.courtInformation.firstNationHeritage,
+        firstNationBand: intake.courtInformation.firstNationBand,
       },
       children: [
         {
@@ -119,9 +126,9 @@ const get = async (
         },
       ],
       programDetails: {
-        transportRequirements: intake.transportation_requirements,
-        schedulingRequirements: intake.scheduling_requirements,
-        suggestedStartDate: intake.suggested_start_date,
+        transportRequirements: intake.programDetails.transportationRequirements,
+        schedulingRequirements: intake.programDetails.schedulingRequirements,
+        suggestedStartDate: intake.programDetails.suggestedStartDate,
         shortTermGoals: [],
         longTermGoals: [],
         familialConcerns: [],
@@ -135,7 +142,6 @@ const get = async (
         ],
       },
     }));
-
     return mappedData;
   } catch (error) {
     return error;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fill in Additional Fields and Restructuring Object for GET Intake ](https://www.notion.so/uwblueprintexecs/Fill-in-Additional-Fields-and-Restructuring-Object-for-GET-Intake-174d8c28af724a9b91fd3b5c6583b070?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added new methods in the familial concern service and child behavior service 
* Restructured GET intakes response with correct information including transport requirements, scheduling requirements, suggested start date, familial concerns,  concerns, and added the case referral and court information objects


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Cards show up on the page 
2. Verify in postman that the response matches the desired response [here](https://www.notion.so/uwblueprintexecs/Intake-Frontend-Backend-b771b1d282974532b97e4d2d233e9144?pvs=4)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The response from GET request (test in postman) 
* make sure UI works with changes


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
)