### PR TITLE
load cases in view all cases page

### DIFF
--- a/frontend/src/components/dashboard/FilteredSection.tsx
+++ b/frontend/src/components/dashboard/FilteredSection.tsx
@@ -22,7 +22,7 @@ const FilteredSection = ({
 }): React.ReactElement => {
   const history = useHistory();
   const viewAllCases = () => {
-    history.push(`/cases?status=${status.toLowerCase()}`);
+    history.push(`/cases/${status.toLowerCase()}`);
   };
 
   return (

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -3,7 +3,7 @@ export const INTAKE_PAGE = "/intake";
 export const VISIT_PAGE = "/visit/:caseId/:visitId";
 export const LOGIN_PAGE = "/login";
 export const SIGNUP_PAGE = "/signup";
-export const CASES_PAGE = "/cases";
+export const CASES_PAGE = "/cases/:status";
 export const CASEOVERVIEW_PAGE = "/caseoverview/:id";
 
 // TODO: Delete these


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Populate Dashboard with GET cases in View All section](https://www.notion.so/uwblueprintexecs/134e1f159caa4f73939d11a700c325ad?v=39cf7d5a98384eb9af2bff2265d0ac8a&p=fab314187b0c4d969172fcff45a7ac2e&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Implement populating CasesPage.tsx with cases from backend through `get_all_cases` API


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. go to cases/<status> and view first 8 cases
2. press load more button at bottom
3. expected result: 8 more cases are shown
4. loadmore button will disappear when no more cases can be pulled


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* once all cases have been loaded, loadmore button will no longer be shown


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
