### PR TITLE
Switching Python versions & Update HEROKU_API_KEY

### DIFF
--- a/backend/python/testing.py
+++ b/backend/python/testing.py
@@ -1,1 +1,0 @@
-# hidden file


### PR DESCRIPTION
Summary of past 4 PRs:
- https://github.com/uwblueprint/childrens-aid-society/pull/231
- https://github.com/uwblueprint/childrens-aid-society/pull/230
- https://github.com/uwblueprint/childrens-aid-society/pull/229
- https://github.com/uwblueprint/childrens-aid-society/pull/228

1. Tried to login to heroku, couldn't; reset password, logged in again
2. Initial saw that Heroku was down for our backend—due to deprecated python version
3. Decided to bump versions (editing `runtime.txt` and editing `Dockerfile`), however, git could not recognize heroku credentials when merged
4. Realized that since I reset the password, the `HEROKU_API_KEY` var changed
5. Got a new api token, set the Github secrets var accordingly